### PR TITLE
feat(clients): Clients module — CRUD API (#5)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
 import { PrismaModule } from './prisma/prisma.module.js';
+import { ClientsModule } from './clients/clients.module.js';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { PrismaModule } from './prisma/prisma.module.js';
       },
     ]),
     PrismaModule,
+    ClientsModule,
   ],
   providers: [
     {

--- a/src/clients/clients.controller.ts
+++ b/src/clients/clients.controller.ts
@@ -1,0 +1,116 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { ClientsService } from './clients.service.js';
+import { CreateClientDto } from './dto/create-client.dto.js';
+import { UpdateClientDto } from './dto/update-client.dto.js';
+import { ClientFilterDto } from './dto/client-filter.dto.js';
+import { AssignAgentDto } from './dto/assign-agent.dto.js';
+import { CurrentUser, type AuthenticatedUser } from '../common/decorators/current-user.decorator.js';
+import { Roles } from '../common/decorators/roles.decorator.js';
+
+@ApiTags('Clients')
+@ApiBearerAuth()
+@Controller('api/clients')
+export class ClientsController {
+  constructor(private readonly clientsService: ClientsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new client' })
+  @ApiResponse({ status: 201, description: 'Client created successfully' })
+  @ApiResponse({ status: 409, description: 'Duplicate email or phone' })
+  create(@Body() dto: CreateClientDto) {
+    return this.clientsService.create(dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List clients with filters and pagination' })
+  findAll(
+    @Query() filter: ClientFilterDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    const isAdminOrManager = user?.roles?.some((r) =>
+      ['admin', 'manager'].includes(r),
+    ) ?? false;
+    return this.clientsService.findAll(filter, user?.sub, isAdminOrManager);
+  }
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Get client statistics' })
+  getStats(@CurrentUser() user: AuthenticatedUser) {
+    const isAdminOrManager = user?.roles?.some((r) =>
+      ['admin', 'manager'].includes(r),
+    ) ?? false;
+    return this.clientsService.getStats(user?.sub, isAdminOrManager);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get client by ID with leads and contracts' })
+  @ApiParam({ name: 'id', description: 'Client UUID' })
+  @ApiResponse({ status: 200, description: 'Client details' })
+  @ApiResponse({ status: 404, description: 'Client not found' })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.clientsService.findOne(id);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update a client' })
+  @ApiParam({ name: 'id', description: 'Client UUID' })
+  @ApiResponse({ status: 200, description: 'Client updated' })
+  @ApiResponse({ status: 404, description: 'Client not found' })
+  @ApiResponse({ status: 409, description: 'Duplicate email or phone' })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateClientDto,
+  ) {
+    return this.clientsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Delete a client (admin only)' })
+  @ApiParam({ name: 'id', description: 'Client UUID' })
+  @ApiResponse({ status: 200, description: 'Client deleted' })
+  @ApiResponse({ status: 404, description: 'Client not found' })
+  remove(@Param('id', ParseUUIDPipe) id: string) {
+    return this.clientsService.remove(id);
+  }
+
+  @Patch(':id/assign')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Assign client to an agent' })
+  @ApiParam({ name: 'id', description: 'Client UUID' })
+  @ApiResponse({ status: 200, description: 'Agent assigned' })
+  @ApiResponse({ status: 404, description: 'Client not found' })
+  assignAgent(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: AssignAgentDto,
+  ) {
+    return this.clientsService.assignAgent(id, dto.agentId);
+  }
+
+  @Get(':id/history')
+  @ApiOperation({ summary: 'Get client interaction history (leads & contracts)' })
+  @ApiParam({ name: 'id', description: 'Client UUID' })
+  @ApiResponse({ status: 200, description: 'Client interaction history' })
+  @ApiResponse({ status: 404, description: 'Client not found' })
+  getHistory(@Param('id', ParseUUIDPipe) id: string) {
+    return this.clientsService.getHistory(id);
+  }
+}

--- a/src/clients/clients.module.ts
+++ b/src/clients/clients.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ClientsController } from './clients.controller.js';
+import { ClientsService } from './clients.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ClientsController],
+  providers: [ClientsService],
+  exports: [ClientsService],
+})
+export class ClientsModule {}

--- a/src/clients/clients.service.spec.ts
+++ b/src/clients/clients.service.spec.ts
@@ -1,0 +1,215 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { ClientsService } from './clients.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { ClientType, ClientSource } from '@prisma/client';
+
+const mockPrisma = {
+  client: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    count: jest.fn(),
+    groupBy: jest.fn(),
+  },
+  lead: { findMany: jest.fn() },
+  contract: { findMany: jest.fn() },
+};
+
+describe('ClientsService', () => {
+  let service: ClientsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClientsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<ClientsService>(ClientsService);
+    jest.clearAllMocks();
+  });
+
+  const sampleClient = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    firstName: 'Ahmed',
+    lastName: 'Hassan',
+    email: 'ahmed@example.com',
+    phone: '+201234567890',
+    nationalId: null,
+    type: ClientType.BUYER,
+    source: ClientSource.WEBSITE,
+    notes: null,
+    assignedAgentId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  describe('create', () => {
+    it('should create a client successfully', async () => {
+      mockPrisma.client.findFirst.mockResolvedValue(null);
+      mockPrisma.client.create.mockResolvedValue(sampleClient);
+
+      const result = await service.create({
+        firstName: 'Ahmed',
+        lastName: 'Hassan',
+        email: 'ahmed@example.com',
+        phone: '+201234567890',
+        type: ClientType.BUYER,
+        source: ClientSource.WEBSITE,
+      });
+
+      expect(result).toEqual(sampleClient);
+      expect(mockPrisma.client.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw ConflictException on duplicate email', async () => {
+      mockPrisma.client.findFirst.mockResolvedValue({
+        ...sampleClient,
+        email: 'ahmed@example.com',
+      });
+
+      await expect(
+        service.create({
+          firstName: 'Test',
+          lastName: 'User',
+          email: 'ahmed@example.com',
+          phone: '+201111111111',
+          type: ClientType.BUYER,
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should throw ConflictException on duplicate phone', async () => {
+      mockPrisma.client.findFirst.mockResolvedValue({
+        ...sampleClient,
+        phone: '+201234567890',
+        email: 'other@example.com',
+      });
+
+      await expect(
+        service.create({
+          firstName: 'Test',
+          lastName: 'User',
+          phone: '+201234567890',
+          type: ClientType.BUYER,
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return paginated results', async () => {
+      const clients = [{ ...sampleClient, _count: { leads: 2, contracts: 1 } }];
+      mockPrisma.client.findMany.mockResolvedValue(clients);
+      mockPrisma.client.count.mockResolvedValue(1);
+
+      const result = await service.findAll(
+        { page: 1, limit: 20, skip: 0 } as any,
+        undefined,
+        true,
+      );
+
+      expect(result.data).toEqual(clients);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+    });
+
+    it('should scope to agent when not admin/manager', async () => {
+      mockPrisma.client.findMany.mockResolvedValue([]);
+      mockPrisma.client.count.mockResolvedValue(0);
+
+      await service.findAll(
+        { page: 1, limit: 20, skip: 0 } as any,
+        'agent-123',
+        false,
+      );
+
+      expect(mockPrisma.client.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ assignedAgentId: 'agent-123' }),
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a client with relations', async () => {
+      mockPrisma.client.findUnique.mockResolvedValue(sampleClient);
+
+      const result = await service.findOne(sampleClient.id);
+      expect(result).toEqual(sampleClient);
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      mockPrisma.client.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update a client', async () => {
+      mockPrisma.client.findUnique.mockResolvedValue(sampleClient);
+      mockPrisma.client.findFirst.mockResolvedValue(null);
+      const updated = { ...sampleClient, firstName: 'Mohamed' };
+      mockPrisma.client.update.mockResolvedValue(updated);
+
+      const result = await service.update(sampleClient.id, {
+        firstName: 'Mohamed',
+      });
+
+      expect(result.firstName).toBe('Mohamed');
+    });
+
+    it('should throw NotFoundException on update of nonexistent client', async () => {
+      mockPrisma.client.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.update('nonexistent', { firstName: 'Test' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a client', async () => {
+      mockPrisma.client.findUnique.mockResolvedValue(sampleClient);
+      mockPrisma.client.delete.mockResolvedValue(sampleClient);
+
+      const result = await service.remove(sampleClient.id);
+      expect(result).toEqual(sampleClient);
+    });
+  });
+
+  describe('assignAgent', () => {
+    it('should assign an agent to a client', async () => {
+      mockPrisma.client.findUnique.mockResolvedValue(sampleClient);
+      const assigned = { ...sampleClient, assignedAgentId: 'agent-456' };
+      mockPrisma.client.update.mockResolvedValue(assigned);
+
+      const result = await service.assignAgent(sampleClient.id, 'agent-456');
+      expect(result.assignedAgentId).toBe('agent-456');
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return aggregated statistics', async () => {
+      mockPrisma.client.count.mockResolvedValue(50);
+      mockPrisma.client.groupBy
+        .mockResolvedValueOnce([{ type: ClientType.BUYER, _count: 30 }])
+        .mockResolvedValueOnce([{ source: ClientSource.WEBSITE, _count: 20 }]);
+
+      const stats = await service.getStats(undefined, true);
+
+      expect(stats.total).toBe(50);
+      expect(stats.byType).toHaveLength(1);
+      expect(stats.bySource).toHaveLength(1);
+    });
+  });
+});

--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -1,0 +1,200 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CreateClientDto } from './dto/create-client.dto.js';
+import { UpdateClientDto } from './dto/update-client.dto.js';
+import { ClientFilterDto } from './dto/client-filter.dto.js';
+import { paginate, type PaginatedResult } from '../common/dto/pagination.dto.js';
+
+@Injectable()
+export class ClientsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateClientDto) {
+    await this.checkDuplicates(dto.email, dto.phone);
+
+    return this.prisma.client.create({ data: dto });
+  }
+
+  async findAll(
+    filter: ClientFilterDto,
+    agentId?: string,
+    isAdminOrManager = false,
+  ): Promise<PaginatedResult<any>> {
+    const where = this.buildWhereClause(filter, agentId, isAdminOrManager);
+
+    const [data, total] = await Promise.all([
+      this.prisma.client.findMany({
+        where,
+        skip: filter.skip,
+        take: filter.limit,
+        orderBy: { [filter.sortBy ?? 'createdAt']: filter.sortOrder ?? 'desc' },
+        include: {
+          _count: { select: { leads: true, contracts: true } },
+        },
+      }),
+      this.prisma.client.count({ where }),
+    ]);
+
+    return paginate(data, total, filter);
+  }
+
+  async findOne(id: string) {
+    const client = await this.prisma.client.findUnique({
+      where: { id },
+      include: {
+        leads: {
+          orderBy: { createdAt: 'desc' },
+          take: 10,
+        },
+        contracts: {
+          orderBy: { createdAt: 'desc' },
+          take: 10,
+        },
+        _count: { select: { leads: true, contracts: true } },
+      },
+    });
+
+    if (!client) {
+      throw new NotFoundException(`Client with ID "${id}" not found`);
+    }
+
+    return client;
+  }
+
+  async update(id: string, dto: UpdateClientDto) {
+    await this.findOne(id);
+
+    if (dto.email || dto.phone) {
+      await this.checkDuplicates(dto.email, dto.phone, id);
+    }
+
+    return this.prisma.client.update({
+      where: { id },
+      data: dto,
+    });
+  }
+
+  async remove(id: string) {
+    await this.findOne(id);
+
+    return this.prisma.client.delete({ where: { id } });
+  }
+
+  async assignAgent(id: string, agentId: string) {
+    await this.findOne(id);
+
+    return this.prisma.client.update({
+      where: { id },
+      data: { assignedAgentId: agentId },
+    });
+  }
+
+  async getHistory(id: string) {
+    await this.findOne(id);
+
+    const [leads, contracts] = await Promise.all([
+      this.prisma.lead.findMany({
+        where: { clientId: id },
+        include: {
+          activities: { orderBy: { createdAt: 'desc' }, take: 5 },
+        },
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.contract.findMany({
+        where: { clientId: id },
+        include: { invoices: true },
+        orderBy: { createdAt: 'desc' },
+      }),
+    ]);
+
+    return { leads, contracts };
+  }
+
+  async getStats(agentId?: string, isAdminOrManager = false) {
+    const where: Prisma.ClientWhereInput =
+      !isAdminOrManager && agentId ? { assignedAgentId: agentId } : {};
+
+    const [total, byType, bySource] = await Promise.all([
+      this.prisma.client.count({ where }),
+      this.prisma.client.groupBy({
+        by: ['type'],
+        where,
+        _count: true,
+      }),
+      this.prisma.client.groupBy({
+        by: ['source'],
+        where,
+        _count: true,
+      }),
+    ]);
+
+    return {
+      total,
+      byType: byType.map((g) => ({ type: g.type, count: g._count })),
+      bySource: bySource.map((g) => ({ source: g.source, count: g._count })),
+    };
+  }
+
+  private buildWhereClause(
+    filter: ClientFilterDto,
+    agentId?: string,
+    isAdminOrManager = false,
+  ): Prisma.ClientWhereInput {
+    const where: Prisma.ClientWhereInput = {};
+
+    if (filter.type) where.type = filter.type;
+    if (filter.source) where.source = filter.source;
+    if (filter.assignedAgentId) where.assignedAgentId = filter.assignedAgentId;
+
+    // Agent scoping: agents only see their own clients unless admin/manager
+    if (!isAdminOrManager && agentId) {
+      where.assignedAgentId = agentId;
+    }
+
+    if (filter.search) {
+      where.OR = [
+        { firstName: { contains: filter.search, mode: 'insensitive' } },
+        { lastName: { contains: filter.search, mode: 'insensitive' } },
+        { email: { contains: filter.search, mode: 'insensitive' } },
+        { phone: { contains: filter.search } },
+        { nationalId: { contains: filter.search } },
+      ];
+    }
+
+    return where;
+  }
+
+  private async checkDuplicates(
+    email?: string,
+    phone?: string,
+    excludeId?: string,
+  ) {
+    const conditions: Prisma.ClientWhereInput[] = [];
+
+    if (email) conditions.push({ email });
+    if (phone) conditions.push({ phone });
+
+    if (conditions.length === 0) return;
+
+    const existing = await this.prisma.client.findFirst({
+      where: {
+        OR: conditions,
+        ...(excludeId ? { NOT: { id: excludeId } } : {}),
+      },
+    });
+
+    if (existing) {
+      if (email && existing.email === email) {
+        throw new ConflictException(`A client with email "${email}" already exists`);
+      }
+      if (phone && existing.phone === phone) {
+        throw new ConflictException(`A client with phone "${phone}" already exists`);
+      }
+    }
+  }
+}

--- a/src/clients/dto/assign-agent.dto.ts
+++ b/src/clients/dto/assign-agent.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class AssignAgentDto {
+  @ApiProperty({ description: 'Agent user ID to assign' })
+  @IsNotEmpty()
+  @IsUUID()
+  agentId: string;
+}

--- a/src/clients/dto/client-filter.dto.ts
+++ b/src/clients/dto/client-filter.dto.ts
@@ -1,0 +1,31 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { ClientType, ClientSource } from '@prisma/client';
+import { PaginationDto } from '../../common/dto/pagination.dto.js';
+
+export class ClientFilterDto extends PaginationDto {
+  @ApiPropertyOptional({ description: 'Filter by client type', enum: ClientType })
+  @IsOptional()
+  @IsEnum(ClientType)
+  type?: ClientType;
+
+  @ApiPropertyOptional({ description: 'Filter by source', enum: ClientSource })
+  @IsOptional()
+  @IsEnum(ClientSource)
+  source?: ClientSource;
+
+  @ApiPropertyOptional({ description: 'Filter by assigned agent ID' })
+  @IsOptional()
+  @IsUUID()
+  assignedAgentId?: string;
+
+  @ApiPropertyOptional({ description: 'Sort field', enum: ['createdAt', 'firstName', 'lastName'] })
+  @IsOptional()
+  @IsString()
+  sortBy?: 'createdAt' | 'firstName' | 'lastName' = 'createdAt';
+
+  @ApiPropertyOptional({ description: 'Sort direction', enum: ['asc', 'desc'] })
+  @IsOptional()
+  @IsString()
+  sortOrder?: 'asc' | 'desc' = 'desc';
+}

--- a/src/clients/dto/create-client.dto.ts
+++ b/src/clients/dto/create-client.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+} from 'class-validator';
+import { ClientType, ClientSource } from '@prisma/client';
+
+export class CreateClientDto {
+  @ApiProperty({ description: 'Client first name', example: 'Ahmed' })
+  @IsNotEmpty()
+  @IsString()
+  firstName: string;
+
+  @ApiProperty({ description: 'Client last name', example: 'Hassan' })
+  @IsNotEmpty()
+  @IsString()
+  lastName: string;
+
+  @ApiPropertyOptional({ description: 'Email address', example: 'ahmed@example.com' })
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @ApiProperty({ description: 'Phone number', example: '+201234567890' })
+  @IsNotEmpty()
+  @IsString()
+  @Matches(/^\+?[0-9]{10,15}$/, { message: 'Phone must be a valid number (10-15 digits, optional + prefix)' })
+  phone: string;
+
+  @ApiPropertyOptional({ description: 'National ID number' })
+  @IsOptional()
+  @IsString()
+  nationalId?: string;
+
+  @ApiProperty({ description: 'Client type', enum: ClientType, example: ClientType.BUYER })
+  @IsNotEmpty()
+  @IsEnum(ClientType)
+  type: ClientType;
+
+  @ApiPropertyOptional({ description: 'Lead source', enum: ClientSource, default: ClientSource.OTHER })
+  @IsOptional()
+  @IsEnum(ClientSource)
+  source?: ClientSource;
+
+  @ApiPropertyOptional({ description: 'Additional notes' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/src/clients/dto/update-client.dto.ts
+++ b/src/clients/dto/update-client.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateClientDto } from './create-client.dto.js';
+
+export class UpdateClientDto extends PartialType(CreateClientDto) {}


### PR DESCRIPTION
## Summary
- Implements full **Clients Module** with NestJS (controller + service + DTOs)
- 8 endpoints: create, list, get by ID, update, delete (admin), assign agent, interaction history, statistics
- Duplicate detection on email & phone, agent scoping, pagination, sorting, text search
- Swagger documentation on all endpoints
- 12 unit tests (all passing)

Closes #5

## Endpoints
| Method | Path | Access |
|--------|------|--------|
| POST | `/api/clients` | All authenticated |
| GET | `/api/clients` | All (agent-scoped) |
| GET | `/api/clients/stats` | All (agent-scoped) |
| GET | `/api/clients/:id` | All |
| PUT | `/api/clients/:id` | All |
| DELETE | `/api/clients/:id` | Admin only |
| PATCH | `/api/clients/:id/assign` | Admin, Manager |
| GET | `/api/clients/:id/history` | All |

## Test plan
- [x] Unit tests for ClientsService (12 tests passing)
- [ ] E2E tests (deferred — requires running DB + auth)
- [x] TypeScript compilation passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)