### PR TITLE
feat(properties): Properties module — CRUD API (#4)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
 import { PrismaModule } from './prisma/prisma.module.js';
 import { ClientsModule } from './clients/clients.module.js';
+import { PropertiesModule } from './properties/properties.module.js';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { ClientsModule } from './clients/clients.module.js';
     ]),
     PrismaModule,
     ClientsModule,
+    PropertiesModule,
   ],
   providers: [
     {

--- a/src/properties/dto/change-status.dto.ts
+++ b/src/properties/dto/change-status.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { PropertyStatus } from '@prisma/client';
+
+export class ChangeStatusDto {
+  @ApiProperty({ description: 'New property status', enum: PropertyStatus })
+  @IsNotEmpty()
+  @IsEnum(PropertyStatus)
+  status: PropertyStatus;
+}

--- a/src/properties/dto/create-property.dto.ts
+++ b/src/properties/dto/create-property.dto.ts
@@ -1,0 +1,91 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsDecimal,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { PropertyType } from '@prisma/client';
+
+export class CreatePropertyDto {
+  @ApiProperty({ description: 'Property title', example: 'Luxury 3BR Apartment in Zamalek' })
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @ApiPropertyOptional({ description: 'Detailed description' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ description: 'Property type', enum: PropertyType, example: PropertyType.APARTMENT })
+  @IsNotEmpty()
+  @IsEnum(PropertyType)
+  type: PropertyType;
+
+  @ApiProperty({ description: 'Price in EGP', example: '2500000.00' })
+  @IsNotEmpty()
+  @IsDecimal({ decimal_digits: '0,2' })
+  price: string;
+
+  @ApiProperty({ description: 'Area in square meters', example: '180.00' })
+  @IsNotEmpty()
+  @IsDecimal({ decimal_digits: '0,2' })
+  area: string;
+
+  @ApiPropertyOptional({ description: 'Number of bedrooms', example: 3 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  bedrooms?: number;
+
+  @ApiPropertyOptional({ description: 'Number of bathrooms', example: 2 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  bathrooms?: number;
+
+  @ApiPropertyOptional({ description: 'Floor number', example: 5 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  floor?: number;
+
+  @ApiProperty({ description: 'Street address', example: '15 Abu El Feda St' })
+  @IsNotEmpty()
+  @IsString()
+  address: string;
+
+  @ApiProperty({ description: 'City', example: 'Cairo' })
+  @IsNotEmpty()
+  @IsString()
+  city: string;
+
+  @ApiProperty({ description: 'Region / district', example: 'Zamalek' })
+  @IsNotEmpty()
+  @IsString()
+  region: string;
+
+  @ApiPropertyOptional({ description: 'Latitude', example: '30.0561000' })
+  @IsOptional()
+  @IsDecimal({ decimal_digits: '0,7' })
+  latitude?: string;
+
+  @ApiPropertyOptional({ description: 'Longitude', example: '31.2243000' })
+  @IsOptional()
+  @IsDecimal({ decimal_digits: '0,7' })
+  longitude?: string;
+
+  @ApiPropertyOptional({ description: 'Features list', example: ['pool', 'gym', 'parking'], type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  features?: string[];
+}

--- a/src/properties/dto/property-filter.dto.ts
+++ b/src/properties/dto/property-filter.dto.ts
@@ -1,0 +1,59 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDecimal, IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { PropertyType, PropertyStatus } from '@prisma/client';
+import { PaginationDto } from '../../common/dto/pagination.dto.js';
+
+export class PropertyFilterDto extends PaginationDto {
+  @ApiPropertyOptional({ description: 'Filter by property type', enum: PropertyType })
+  @IsOptional()
+  @IsEnum(PropertyType)
+  type?: PropertyType;
+
+  @ApiPropertyOptional({ description: 'Filter by status', enum: PropertyStatus })
+  @IsOptional()
+  @IsEnum(PropertyStatus)
+  status?: PropertyStatus;
+
+  @ApiPropertyOptional({ description: 'Minimum price' })
+  @IsOptional()
+  @IsDecimal({ decimal_digits: '0,2' })
+  minPrice?: string;
+
+  @ApiPropertyOptional({ description: 'Maximum price' })
+  @IsOptional()
+  @IsDecimal({ decimal_digits: '0,2' })
+  maxPrice?: string;
+
+  @ApiPropertyOptional({ description: 'Minimum area (sqm)' })
+  @IsOptional()
+  @IsDecimal({ decimal_digits: '0,2' })
+  minArea?: string;
+
+  @ApiPropertyOptional({ description: 'Maximum area (sqm)' })
+  @IsOptional()
+  @IsDecimal({ decimal_digits: '0,2' })
+  maxArea?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by city' })
+  @IsOptional()
+  @IsString()
+  city?: string;
+
+  @ApiPropertyOptional({ description: 'Minimum bedrooms' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  bedrooms?: number;
+
+  @ApiPropertyOptional({ description: 'Sort field', enum: ['createdAt', 'price', 'area', 'title'] })
+  @IsOptional()
+  @IsString()
+  sortBy?: 'createdAt' | 'price' | 'area' | 'title' = 'createdAt';
+
+  @ApiPropertyOptional({ description: 'Sort direction', enum: ['asc', 'desc'] })
+  @IsOptional()
+  @IsString()
+  sortOrder?: 'asc' | 'desc' = 'desc';
+}

--- a/src/properties/dto/update-property.dto.ts
+++ b/src/properties/dto/update-property.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreatePropertyDto } from './create-property.dto.js';
+
+export class UpdatePropertyDto extends PartialType(CreatePropertyDto) {}

--- a/src/properties/properties.controller.ts
+++ b/src/properties/properties.controller.ts
@@ -1,0 +1,123 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { PropertiesService } from './properties.service.js';
+import { CreatePropertyDto } from './dto/create-property.dto.js';
+import { UpdatePropertyDto } from './dto/update-property.dto.js';
+import { PropertyFilterDto } from './dto/property-filter.dto.js';
+import { ChangeStatusDto } from './dto/change-status.dto.js';
+import { AssignAgentDto } from '../clients/dto/assign-agent.dto.js';
+import { CurrentUser, type AuthenticatedUser } from '../common/decorators/current-user.decorator.js';
+import { Roles } from '../common/decorators/roles.decorator.js';
+import { AuthGuard } from '../common/guards/auth.guard.js';
+
+@ApiTags('Properties')
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Controller('api/properties')
+export class PropertiesController {
+  constructor(private readonly propertiesService: PropertiesService) {}
+
+  @Post()
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Create a new property' })
+  @ApiResponse({ status: 201, description: 'Property created successfully' })
+  create(@Body() dto: CreatePropertyDto) {
+    return this.propertiesService.create(dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List properties with filters and pagination' })
+  findAll(
+    @Query() filter: PropertyFilterDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    const isAdminOrManager = user?.roles?.some((r) =>
+      ['admin', 'manager'].includes(r),
+    ) ?? false;
+    return this.propertiesService.findAll(filter, user?.sub, isAdminOrManager);
+  }
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Get property statistics' })
+  getStats(@CurrentUser() user: AuthenticatedUser) {
+    const isAdminOrManager = user?.roles?.some((r) =>
+      ['admin', 'manager'].includes(r),
+    ) ?? false;
+    return this.propertiesService.getStats(user?.sub, isAdminOrManager);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get property by ID with images' })
+  @ApiParam({ name: 'id', description: 'Property UUID' })
+  @ApiResponse({ status: 200, description: 'Property details' })
+  @ApiResponse({ status: 404, description: 'Property not found' })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.propertiesService.findOne(id);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update a property' })
+  @ApiParam({ name: 'id', description: 'Property UUID' })
+  @ApiResponse({ status: 200, description: 'Property updated' })
+  @ApiResponse({ status: 404, description: 'Property not found' })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdatePropertyDto,
+  ) {
+    return this.propertiesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Soft-delete a property (sets status to OFF_MARKET)' })
+  @ApiParam({ name: 'id', description: 'Property UUID' })
+  @ApiResponse({ status: 200, description: 'Property soft-deleted' })
+  @ApiResponse({ status: 404, description: 'Property not found' })
+  remove(@Param('id', ParseUUIDPipe) id: string) {
+    return this.propertiesService.remove(id);
+  }
+
+  @Patch(':id/status')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Change property status' })
+  @ApiParam({ name: 'id', description: 'Property UUID' })
+  @ApiResponse({ status: 200, description: 'Status updated' })
+  @ApiResponse({ status: 404, description: 'Property not found' })
+  changeStatus(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: ChangeStatusDto,
+  ) {
+    return this.propertiesService.changeStatus(id, dto.status);
+  }
+
+  @Patch(':id/assign')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Assign property to an agent' })
+  @ApiParam({ name: 'id', description: 'Property UUID' })
+  @ApiResponse({ status: 200, description: 'Agent assigned' })
+  @ApiResponse({ status: 404, description: 'Property not found' })
+  assignAgent(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: AssignAgentDto,
+  ) {
+    return this.propertiesService.assignAgent(id, dto.agentId);
+  }
+}

--- a/src/properties/properties.module.ts
+++ b/src/properties/properties.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PropertiesController } from './properties.controller.js';
+import { PropertiesService } from './properties.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [PropertiesController],
+  providers: [PropertiesService],
+  exports: [PropertiesService],
+})
+export class PropertiesModule {}

--- a/src/properties/properties.service.spec.ts
+++ b/src/properties/properties.service.spec.ts
@@ -1,0 +1,205 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { PropertiesService } from './properties.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { PropertyType, PropertyStatus } from '@prisma/client';
+
+const mockPrisma = {
+  property: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    count: jest.fn(),
+    groupBy: jest.fn(),
+  },
+};
+
+describe('PropertiesService', () => {
+  let service: PropertiesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PropertiesService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<PropertiesService>(PropertiesService);
+    jest.clearAllMocks();
+  });
+
+  const sampleProperty = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    title: 'Luxury Apartment in Zamalek',
+    description: 'A spacious 3-bedroom apartment',
+    type: PropertyType.APARTMENT,
+    status: PropertyStatus.AVAILABLE,
+    price: '2500000.00',
+    area: '180.00',
+    bedrooms: 3,
+    bathrooms: 2,
+    floor: 5,
+    address: '15 Abu El Feda St',
+    city: 'Cairo',
+    region: 'Zamalek',
+    latitude: null,
+    longitude: null,
+    features: ['pool', 'gym'],
+    assignedAgentId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  describe('create', () => {
+    it('should create a property', async () => {
+      mockPrisma.property.create.mockResolvedValue(sampleProperty);
+
+      const dto = {
+        title: 'Luxury Apartment in Zamalek',
+        description: 'A spacious 3-bedroom apartment',
+        type: PropertyType.APARTMENT,
+        price: '2500000.00',
+        area: '180.00',
+        bedrooms: 3,
+        bathrooms: 2,
+        floor: 5,
+        address: '15 Abu El Feda St',
+        city: 'Cairo',
+        region: 'Zamalek',
+        features: ['pool', 'gym'],
+      };
+
+      const result = await service.create(dto);
+      expect(result).toEqual(sampleProperty);
+      expect(mockPrisma.property.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return paginated properties', async () => {
+      mockPrisma.property.findMany.mockResolvedValue([sampleProperty]);
+      mockPrisma.property.count.mockResolvedValue(1);
+
+      const result = await service.findAll({ page: 1, limit: 20, skip: 0 } as any);
+      expect(result.data).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+    });
+
+    it('should scope to agent when not admin', async () => {
+      mockPrisma.property.findMany.mockResolvedValue([]);
+      mockPrisma.property.count.mockResolvedValue(0);
+
+      await service.findAll({ page: 1, limit: 20, skip: 0 } as any, 'agent-id', false);
+
+      const whereArg = mockPrisma.property.findMany.mock.calls[0][0].where;
+      expect(whereArg.assignedAgentId).toBe('agent-id');
+    });
+
+    it('should not scope when admin/manager', async () => {
+      mockPrisma.property.findMany.mockResolvedValue([sampleProperty]);
+      mockPrisma.property.count.mockResolvedValue(1);
+
+      await service.findAll({ page: 1, limit: 20, skip: 0 } as any, 'agent-id', true);
+
+      const whereArg = mockPrisma.property.findMany.mock.calls[0][0].where;
+      expect(whereArg.assignedAgentId).toBeUndefined();
+    });
+
+    it('should apply price range filters', async () => {
+      mockPrisma.property.findMany.mockResolvedValue([]);
+      mockPrisma.property.count.mockResolvedValue(0);
+
+      await service.findAll({
+        page: 1, limit: 20, skip: 0,
+        minPrice: '100000', maxPrice: '500000',
+      } as any);
+
+      const whereArg = mockPrisma.property.findMany.mock.calls[0][0].where;
+      expect(whereArg.price).toEqual({ gte: '100000', lte: '500000' });
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a property with images', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue(sampleProperty);
+
+      const result = await service.findOne(sampleProperty.id);
+      expect(result).toEqual(sampleProperty);
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a property', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue({ id: sampleProperty.id });
+      mockPrisma.property.update.mockResolvedValue({ ...sampleProperty, title: 'Updated' });
+
+      const result = await service.update(sampleProperty.id, { title: 'Updated' });
+      expect(result.title).toBe('Updated');
+    });
+
+    it('should throw NotFoundException when property does not exist', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue(null);
+
+      await expect(service.update('nonexistent', { title: 'X' })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should soft-delete by setting status to OFF_MARKET', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue({ id: sampleProperty.id });
+      mockPrisma.property.update.mockResolvedValue({ ...sampleProperty, status: PropertyStatus.OFF_MARKET });
+
+      const result = await service.remove(sampleProperty.id);
+      expect(result.status).toBe(PropertyStatus.OFF_MARKET);
+      expect(mockPrisma.property.update).toHaveBeenCalledWith({
+        where: { id: sampleProperty.id },
+        data: { status: 'OFF_MARKET' },
+      });
+    });
+  });
+
+  describe('changeStatus', () => {
+    it('should update property status', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue({ id: sampleProperty.id });
+      mockPrisma.property.update.mockResolvedValue({ ...sampleProperty, status: PropertyStatus.RESERVED });
+
+      const result = await service.changeStatus(sampleProperty.id, PropertyStatus.RESERVED);
+      expect(result.status).toBe(PropertyStatus.RESERVED);
+    });
+  });
+
+  describe('assignAgent', () => {
+    it('should assign an agent to a property', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue({ id: sampleProperty.id });
+      mockPrisma.property.update.mockResolvedValue({ ...sampleProperty, assignedAgentId: 'agent-1' });
+
+      const result = await service.assignAgent(sampleProperty.id, 'agent-1');
+      expect(result.assignedAgentId).toBe('agent-1');
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return property statistics', async () => {
+      mockPrisma.property.count.mockResolvedValue(10);
+      mockPrisma.property.groupBy
+        .mockResolvedValueOnce([{ type: PropertyType.APARTMENT, _count: 5 }])
+        .mockResolvedValueOnce([{ status: PropertyStatus.AVAILABLE, _count: 8 }])
+        .mockResolvedValueOnce([{ city: 'Cairo', _count: 7 }]);
+
+      const result = await service.getStats();
+      expect(result.total).toBe(10);
+      expect(result.byType).toHaveLength(1);
+      expect(result.byStatus).toHaveLength(1);
+      expect(result.byCity).toHaveLength(1);
+    });
+  });
+});

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -1,0 +1,206 @@
+import {
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CreatePropertyDto } from './dto/create-property.dto.js';
+import { UpdatePropertyDto } from './dto/update-property.dto.js';
+import { PropertyFilterDto } from './dto/property-filter.dto.js';
+import { paginate, type PaginatedResult } from '../common/dto/pagination.dto.js';
+
+@Injectable()
+export class PropertiesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreatePropertyDto) {
+    return this.prisma.property.create({
+      data: {
+        title: dto.title,
+        description: dto.description,
+        type: dto.type,
+        price: dto.price,
+        area: dto.area,
+        bedrooms: dto.bedrooms,
+        bathrooms: dto.bathrooms,
+        floor: dto.floor,
+        address: dto.address,
+        city: dto.city,
+        region: dto.region,
+        latitude: dto.latitude,
+        longitude: dto.longitude,
+        features: dto.features ?? undefined,
+      },
+    });
+  }
+
+  async findAll(
+    filter: PropertyFilterDto,
+    agentId?: string,
+    isAdminOrManager = false,
+  ): Promise<PaginatedResult<any>> {
+    const where = this.buildWhereClause(filter, agentId, isAdminOrManager);
+
+    const [data, total] = await Promise.all([
+      this.prisma.property.findMany({
+        where,
+        skip: filter.skip,
+        take: filter.limit,
+        orderBy: { [filter.sortBy ?? 'createdAt']: filter.sortOrder ?? 'desc' },
+        include: {
+          images: {
+            where: { isPrimary: true },
+            take: 1,
+          },
+          _count: { select: { leads: true, contracts: true } },
+        },
+      }),
+      this.prisma.property.count({ where }),
+    ]);
+
+    return paginate(data, total, filter);
+  }
+
+  async findOne(id: string) {
+    const property = await this.prisma.property.findUnique({
+      where: { id },
+      include: {
+        images: { orderBy: { order: 'asc' } },
+        _count: { select: { leads: true, contracts: true } },
+      },
+    });
+
+    if (!property) {
+      throw new NotFoundException(`Property with ID "${id}" not found`);
+    }
+
+    return property;
+  }
+
+  async update(id: string, dto: UpdatePropertyDto) {
+    await this.ensureExists(id);
+
+    return this.prisma.property.update({
+      where: { id },
+      data: {
+        ...dto,
+        features: dto.features ?? undefined,
+      },
+    });
+  }
+
+  async remove(id: string) {
+    await this.ensureExists(id);
+
+    return this.prisma.property.update({
+      where: { id },
+      data: { status: 'OFF_MARKET' },
+    });
+  }
+
+  async changeStatus(id: string, status: string) {
+    await this.ensureExists(id);
+
+    return this.prisma.property.update({
+      where: { id },
+      data: { status: status as any },
+    });
+  }
+
+  async assignAgent(id: string, agentId: string) {
+    await this.ensureExists(id);
+
+    return this.prisma.property.update({
+      where: { id },
+      data: { assignedAgentId: agentId },
+    });
+  }
+
+  async getStats(agentId?: string, isAdminOrManager = false) {
+    const where: Prisma.PropertyWhereInput =
+      !isAdminOrManager && agentId ? { assignedAgentId: agentId } : {};
+
+    const [total, byType, byStatus, byCity] = await Promise.all([
+      this.prisma.property.count({ where }),
+      this.prisma.property.groupBy({
+        by: ['type'],
+        where,
+        _count: true,
+      }),
+      this.prisma.property.groupBy({
+        by: ['status'],
+        where,
+        _count: true,
+      }),
+      this.prisma.property.groupBy({
+        by: ['city'],
+        where,
+        _count: true,
+        orderBy: { _count: { city: 'desc' } },
+        take: 10,
+      }),
+    ]);
+
+    return {
+      total,
+      byType: byType.map((g) => ({ type: g.type, count: g._count })),
+      byStatus: byStatus.map((g) => ({ status: g.status, count: g._count })),
+      byCity: byCity.map((g) => ({ city: g.city, count: g._count })),
+    };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.property.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    if (!exists) {
+      throw new NotFoundException(`Property with ID "${id}" not found`);
+    }
+  }
+
+  private buildWhereClause(
+    filter: PropertyFilterDto,
+    agentId?: string,
+    isAdminOrManager = false,
+  ): Prisma.PropertyWhereInput {
+    const where: Prisma.PropertyWhereInput = {};
+
+    if (filter.type) where.type = filter.type;
+    if (filter.status) where.status = filter.status;
+    if (filter.city) where.city = { contains: filter.city, mode: 'insensitive' };
+
+    if (filter.minPrice || filter.maxPrice) {
+      where.price = {};
+      if (filter.minPrice) where.price.gte = filter.minPrice;
+      if (filter.maxPrice) where.price.lte = filter.maxPrice;
+    }
+
+    if (filter.minArea || filter.maxArea) {
+      where.area = {};
+      if (filter.minArea) where.area.gte = filter.minArea;
+      if (filter.maxArea) where.area.lte = filter.maxArea;
+    }
+
+    if (filter.bedrooms != null) {
+      where.bedrooms = { gte: filter.bedrooms };
+    }
+
+    // Agent scoping: agents only see their own properties unless admin/manager
+    if (!isAdminOrManager && agentId) {
+      where.assignedAgentId = agentId;
+    }
+
+    if (filter.search) {
+      where.OR = [
+        { title: { contains: filter.search, mode: 'insensitive' } },
+        { description: { contains: filter.search, mode: 'insensitive' } },
+        { address: { contains: filter.search, mode: 'insensitive' } },
+        { city: { contains: filter.search, mode: 'insensitive' } },
+        { region: { contains: filter.search, mode: 'insensitive' } },
+      ];
+    }
+
+    return where;
+  }
+}


### PR DESCRIPTION
## Summary
- Full Properties CRUD module (create, list, get, update, soft-delete)
- Dynamic filtering: type, status, price range, area range, city, bedrooms, text search
- Pagination & sorting (price, area, createdAt, title)
- Agent scoping — agents see only their assigned properties
- Status change (`PATCH /status`) and agent assignment (`PATCH /assign`) endpoints
- Property statistics endpoint grouped by type, status, and city
- Swagger documentation on all endpoints
- 13 unit tests — all passing

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/properties` | Create property (admin, manager) |
| GET | `/api/properties` | List with filters & pagination |
| GET | `/api/properties/stats` | Statistics |
| GET | `/api/properties/:id` | Get with images |
| PUT | `/api/properties/:id` | Update |
| DELETE | `/api/properties/:id` | Soft delete (admin) |
| PATCH | `/api/properties/:id/status` | Change status |
| PATCH | `/api/properties/:id/assign` | Assign agent |

## Test plan
- [x] Unit tests for PropertiesService (13 tests passing)
- [ ] Manual Swagger testing
- [ ] E2E tests (future)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)