### PR TITLE
feat(contracts): Contracts module — CRUD API with invoices & status management

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { PrismaModule } from './prisma/prisma.module.js';
 import { ClientsModule } from './clients/clients.module.js';
 import { PropertiesModule } from './properties/properties.module.js';
+import { ContractsModule } from './contracts/contracts.module.js';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { PropertiesModule } from './properties/properties.module.js';
     PrismaModule,
     ClientsModule,
     PropertiesModule,
+    ContractsModule,
   ],
   providers: [
     {

--- a/src/contracts/contracts.controller.spec.ts
+++ b/src/contracts/contracts.controller.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContractsController } from './contracts.controller';
+import { ContractsService } from './contracts.service';
+import { ContractType, ContractStatus } from '@prisma/client';
+import { AuthenticatedUser } from '../common/decorators/current-user.decorator';
+
+const mockService = {
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  changeStatus: jest.fn(),
+  findContractInvoices: jest.fn(),
+  generateInvoices: jest.fn(),
+  getStats: jest.fn(),
+  getExpiring: jest.fn(),
+};
+
+const adminUser: AuthenticatedUser = {
+  sub: 'admin-001',
+  email: 'admin@test.com',
+  roles: ['admin'],
+};
+
+describe('ContractsController', () => {
+  let controller: ContractsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ContractsController],
+      providers: [{ provide: ContractsService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get<ContractsController>(ContractsController);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should create a contract', async () => {
+    const dto = {
+      type: ContractType.SALE,
+      propertyId: 'prop-001',
+      clientId: 'client-001',
+      startDate: '2026-01-01',
+      totalAmount: 100000,
+    };
+    mockService.create.mockResolvedValue({ id: 'c1', ...dto });
+
+    const result = await controller.create(dto, adminUser);
+    expect(result.id).toBe('c1');
+    expect(mockService.create).toHaveBeenCalledWith(dto, adminUser);
+  });
+
+  it('should list contracts', async () => {
+    const paginated = { data: [], total: 0, page: 1, limit: 20, totalPages: 0 };
+    mockService.findAll.mockResolvedValue(paginated);
+
+    const result = await controller.findAll({} as any, adminUser);
+    expect(result).toEqual(paginated);
+  });
+
+  it('should get contract stats', async () => {
+    const stats = { total: 5, byStatus: {}, byType: {}, totalValue: 0 };
+    mockService.getStats.mockResolvedValue(stats);
+
+    const result = await controller.getStats(adminUser);
+    expect(result.total).toBe(5);
+  });
+
+  it('should get expiring contracts', async () => {
+    mockService.getExpiring.mockResolvedValue([]);
+    const result = await controller.getExpiring(30, adminUser);
+    expect(result).toEqual([]);
+  });
+
+  it('should get single contract', async () => {
+    mockService.findOne.mockResolvedValue({ id: 'c1' });
+    const result = await controller.findOne('c1', adminUser);
+    expect(result.id).toBe('c1');
+  });
+
+  it('should change contract status', async () => {
+    mockService.changeStatus.mockResolvedValue({ id: 'c1', status: ContractStatus.ACTIVE });
+    const result = await controller.changeStatus('c1', { status: ContractStatus.ACTIVE });
+    expect(result.status).toBe(ContractStatus.ACTIVE);
+  });
+
+  it('should list contract invoices', async () => {
+    mockService.findContractInvoices.mockResolvedValue([]);
+    const result = await controller.findContractInvoices('c1');
+    expect(result).toEqual([]);
+  });
+
+  it('should generate invoices', async () => {
+    mockService.generateInvoices.mockResolvedValue([{ id: 'inv1' }]);
+    const result = await controller.generateInvoices('c1', {});
+    expect(result).toHaveLength(1);
+  });
+});

--- a/src/contracts/contracts.controller.ts
+++ b/src/contracts/contracts.controller.ts
@@ -1,0 +1,141 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Patch,
+  Param,
+  Body,
+  Query,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { ContractsService } from './contracts.service.js';
+import { CreateContractDto } from './dto/create-contract.dto.js';
+import { UpdateContractDto } from './dto/update-contract.dto.js';
+import { ContractFilterDto } from './dto/filter-contract.dto.js';
+import { ChangeContractStatusDto } from './dto/change-status.dto.js';
+import { GenerateInvoicesDto } from './dto/generate-invoices.dto.js';
+import { Roles } from '../common/decorators/roles.decorator.js';
+import { CurrentUser } from '../common/decorators/current-user.decorator.js';
+import type { AuthenticatedUser } from '../common/decorators/current-user.decorator.js';
+
+@ApiTags('Contracts')
+@ApiBearerAuth()
+@Controller('api/contracts')
+export class ContractsController {
+  constructor(private readonly contractsService: ContractsService) {}
+
+  @Post()
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Create a new contract' })
+  @ApiResponse({ status: 201, description: 'Contract created' })
+  @ApiResponse({ status: 400, description: 'Validation error or property not available' })
+  @ApiResponse({ status: 404, description: 'Property or client not found' })
+  create(
+    @Body() dto: CreateContractDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.contractsService.create(dto, user);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List contracts with filters and pagination' })
+  @ApiResponse({ status: 200, description: 'Paginated list of contracts' })
+  findAll(
+    @Query() filter: ContractFilterDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.contractsService.findAll(filter, user);
+  }
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Get contract statistics' })
+  @ApiResponse({ status: 200, description: 'Contract statistics' })
+  getStats(@CurrentUser() user: AuthenticatedUser) {
+    return this.contractsService.getStats(user);
+  }
+
+  @Get('expiring')
+  @ApiOperation({ summary: 'Get contracts expiring in the next N days' })
+  @ApiQuery({ name: 'days', required: false, type: Number, description: 'Days ahead (default 30)' })
+  @ApiResponse({ status: 200, description: 'List of expiring contracts' })
+  getExpiring(
+    @Query('days') days: number,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.contractsService.getExpiring(days ? Number(days) : 30, user);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get contract by ID with property, client, and invoices' })
+  @ApiParam({ name: 'id', type: String })
+  @ApiResponse({ status: 200, description: 'Contract details' })
+  @ApiResponse({ status: 404, description: 'Contract not found' })
+  findOne(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.contractsService.findOne(id, user);
+  }
+
+  @Put(':id')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Update a contract' })
+  @ApiParam({ name: 'id', type: String })
+  @ApiResponse({ status: 200, description: 'Contract updated' })
+  @ApiResponse({ status: 404, description: 'Contract not found' })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateContractDto,
+  ) {
+    return this.contractsService.update(id, dto);
+  }
+
+  @Patch(':id/status')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Change contract status' })
+  @ApiParam({ name: 'id', type: String })
+  @ApiResponse({ status: 200, description: 'Status updated' })
+  @ApiResponse({ status: 400, description: 'Invalid status transition' })
+  @ApiResponse({ status: 404, description: 'Contract not found' })
+  changeStatus(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: ChangeContractStatusDto,
+  ) {
+    return this.contractsService.changeStatus(id, dto);
+  }
+
+  @Get(':id/invoices')
+  @ApiOperation({ summary: 'List invoices for a contract' })
+  @ApiParam({ name: 'id', type: String })
+  @ApiResponse({ status: 200, description: 'Contract invoices' })
+  @ApiResponse({ status: 404, description: 'Contract not found' })
+  findContractInvoices(@Param('id', ParseUUIDPipe) id: string) {
+    return this.contractsService.findContractInvoices(id);
+  }
+
+  @Post(':id/generate-invoices')
+  @Roles('admin', 'manager')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Auto-generate invoices from payment terms' })
+  @ApiParam({ name: 'id', type: String })
+  @ApiResponse({ status: 200, description: 'Invoices generated' })
+  @ApiResponse({ status: 400, description: 'All invoices already generated or contract cancelled' })
+  @ApiResponse({ status: 404, description: 'Contract not found' })
+  generateInvoices(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: GenerateInvoicesDto,
+  ) {
+    return this.contractsService.generateInvoices(id, dto);
+  }
+}

--- a/src/contracts/contracts.module.ts
+++ b/src/contracts/contracts.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ContractsController } from './contracts.controller.js';
+import { ContractsService } from './contracts.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ContractsController],
+  providers: [ContractsService],
+  exports: [ContractsService],
+})
+export class ContractsModule {}

--- a/src/contracts/contracts.service.spec.ts
+++ b/src/contracts/contracts.service.spec.ts
@@ -1,0 +1,305 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
+import { ContractsService } from './contracts.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { ContractType, ContractStatus, PropertyStatus, InvoiceStatus } from '@prisma/client';
+import { AuthenticatedUser } from '../common/decorators/current-user.decorator';
+
+const mockPrisma: Record<string, any> = {
+  contract: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    count: jest.fn(),
+    groupBy: jest.fn(),
+    aggregate: jest.fn(),
+  },
+  property: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  client: {
+    findUnique: jest.fn(),
+  },
+  invoice: {
+    findMany: jest.fn(),
+    createMany: jest.fn(),
+  },
+  $transaction: jest.fn((fn: (prisma: any) => any) => fn(mockPrisma)),
+};
+
+const adminUser: AuthenticatedUser = {
+  sub: 'admin-001',
+  email: 'admin@test.com',
+  roles: ['admin'],
+};
+
+const agentUser: AuthenticatedUser = {
+  sub: 'agent-001',
+  email: 'agent@test.com',
+  roles: ['agent'],
+};
+
+const mockProperty = {
+  id: 'prop-001',
+  title: 'Test Property',
+  status: PropertyStatus.AVAILABLE,
+};
+
+const mockClient = {
+  id: 'client-001',
+  firstName: 'John',
+  lastName: 'Doe',
+};
+
+const mockContract = {
+  id: 'contract-001',
+  type: ContractType.SALE,
+  propertyId: 'prop-001',
+  clientId: 'client-001',
+  agentId: 'admin-001',
+  startDate: new Date('2026-01-01'),
+  endDate: new Date('2027-01-01'),
+  totalAmount: 100000,
+  paymentTerms: { installments: 12, frequency: 'monthly' },
+  status: ContractStatus.DRAFT,
+  notes: null,
+  documentUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  property: mockProperty,
+  client: mockClient,
+  invoices: [],
+};
+
+describe('ContractsService', () => {
+  let service: ContractsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContractsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<ContractsService>(ContractsService);
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should create a contract and update property status', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue(mockProperty);
+      mockPrisma.client.findUnique.mockResolvedValue(mockClient);
+      mockPrisma.contract.create.mockResolvedValue(mockContract);
+      mockPrisma.property.update.mockResolvedValue({ ...mockProperty, status: PropertyStatus.SOLD });
+
+      const result = await service.create(
+        {
+          type: ContractType.SALE,
+          propertyId: 'prop-001',
+          clientId: 'client-001',
+          startDate: '2026-01-01',
+          totalAmount: 100000,
+        },
+        adminUser,
+      );
+
+      expect(result).toEqual(mockContract);
+      expect(mockPrisma.property.update).toHaveBeenCalledWith({
+        where: { id: 'prop-001' },
+        data: { status: PropertyStatus.SOLD },
+      });
+    });
+
+    it('should throw if property not found', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.create(
+          {
+            type: ContractType.SALE,
+            propertyId: 'nonexistent',
+            clientId: 'client-001',
+            startDate: '2026-01-01',
+            totalAmount: 100000,
+          },
+          adminUser,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw if property is not available', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue({
+        ...mockProperty,
+        status: PropertyStatus.SOLD,
+      });
+
+      await expect(
+        service.create(
+          {
+            type: ContractType.SALE,
+            propertyId: 'prop-001',
+            clientId: 'client-001',
+            startDate: '2026-01-01',
+            totalAmount: 100000,
+          },
+          adminUser,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw if client not found', async () => {
+      mockPrisma.property.findUnique.mockResolvedValue(mockProperty);
+      mockPrisma.client.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.create(
+          {
+            type: ContractType.SALE,
+            propertyId: 'prop-001',
+            clientId: 'nonexistent',
+            startDate: '2026-01-01',
+            totalAmount: 100000,
+          },
+          adminUser,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a contract with relations', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue(mockContract);
+
+      const result = await service.findOne('contract-001', adminUser);
+      expect(result).toEqual(mockContract);
+    });
+
+    it('should throw if contract not found', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('nonexistent', adminUser)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException for agent viewing another agent contract', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        agentId: 'other-agent',
+      });
+
+      await expect(service.findOne('contract-001', agentUser)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('changeStatus', () => {
+    it('should change DRAFT to ACTIVE', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue(mockContract);
+      mockPrisma.contract.update.mockResolvedValue({
+        ...mockContract,
+        status: ContractStatus.ACTIVE,
+      });
+
+      const result = await service.changeStatus('contract-001', {
+        status: ContractStatus.ACTIVE,
+      });
+
+      expect(result.status).toBe(ContractStatus.ACTIVE);
+    });
+
+    it('should reject invalid transition (COMPLETED -> DRAFT)', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        status: ContractStatus.COMPLETED,
+      });
+
+      await expect(
+        service.changeStatus('contract-001', { status: ContractStatus.DRAFT }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should restore property status on cancellation', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        status: ContractStatus.ACTIVE,
+      });
+      mockPrisma.contract.update.mockResolvedValue({
+        ...mockContract,
+        status: ContractStatus.CANCELLED,
+      });
+      mockPrisma.property.update.mockResolvedValue({
+        ...mockProperty,
+        status: PropertyStatus.AVAILABLE,
+      });
+
+      await service.changeStatus('contract-001', {
+        status: ContractStatus.CANCELLED,
+      });
+
+      expect(mockPrisma.property.update).toHaveBeenCalledWith({
+        where: { id: 'prop-001' },
+        data: { status: PropertyStatus.AVAILABLE },
+      });
+    });
+  });
+
+  describe('generateInvoices', () => {
+    it('should generate invoices based on payment terms', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue(mockContract);
+      mockPrisma.invoice.createMany.mockResolvedValue({ count: 12 });
+      mockPrisma.invoice.findMany.mockResolvedValue([]);
+
+      await service.generateInvoices('contract-001', {});
+
+      expect(mockPrisma.invoice.createMany).toHaveBeenCalledWith({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            contractId: 'contract-001',
+            status: InvoiceStatus.PENDING,
+          }),
+        ]),
+      });
+    });
+
+    it('should throw for cancelled contract', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        status: ContractStatus.CANCELLED,
+      });
+
+      await expect(
+        service.generateInvoices('contract-001', {}),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return contract statistics', async () => {
+      mockPrisma.contract.count.mockResolvedValue(10);
+      mockPrisma.contract.groupBy
+        .mockResolvedValueOnce([
+          { status: ContractStatus.ACTIVE, _count: { id: 5 } },
+          { status: ContractStatus.DRAFT, _count: { id: 3 } },
+        ])
+        .mockResolvedValueOnce([
+          { type: ContractType.SALE, _count: { id: 6 } },
+          { type: ContractType.RENT, _count: { id: 4 } },
+        ]);
+      mockPrisma.contract.aggregate.mockResolvedValue({
+        _sum: { totalAmount: 500000 },
+      });
+
+      const result = await service.getStats(adminUser);
+
+      expect(result.total).toBe(10);
+      expect(result.byStatus.ACTIVE).toBe(5);
+      expect(result.byType.SALE).toBe(6);
+      expect(result.totalValue).toBe(500000);
+    });
+  });
+});

--- a/src/contracts/contracts.service.ts
+++ b/src/contracts/contracts.service.ts
@@ -1,0 +1,374 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Prisma, ContractStatus, PropertyStatus, InvoiceStatus } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CreateContractDto } from './dto/create-contract.dto.js';
+import { UpdateContractDto } from './dto/update-contract.dto.js';
+import { ContractFilterDto } from './dto/filter-contract.dto.js';
+import { ChangeContractStatusDto } from './dto/change-status.dto.js';
+import { GenerateInvoicesDto } from './dto/generate-invoices.dto.js';
+import { paginate, PaginatedResult } from '../common/dto/pagination.dto.js';
+import { AuthenticatedUser } from '../common/decorators/current-user.decorator.js';
+
+@Injectable()
+export class ContractsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateContractDto, user: AuthenticatedUser) {
+    // Validate property exists and is available
+    const property = await this.prisma.property.findUnique({
+      where: { id: dto.propertyId },
+    });
+
+    if (!property) {
+      throw new NotFoundException(`Property ${dto.propertyId} not found`);
+    }
+
+    if (property.status !== PropertyStatus.AVAILABLE) {
+      throw new BadRequestException(
+        `Property is not available (current status: ${property.status})`,
+      );
+    }
+
+    // Validate client exists
+    const client = await this.prisma.client.findUnique({
+      where: { id: dto.clientId },
+    });
+
+    if (!client) {
+      throw new NotFoundException(`Client ${dto.clientId} not found`);
+    }
+
+    // Determine new property status based on contract type
+    const propertyStatusMap: Record<string, PropertyStatus> = {
+      SALE: PropertyStatus.SOLD,
+      RENT: PropertyStatus.RENTED,
+      LEASE: PropertyStatus.RENTED,
+    };
+    const newPropertyStatus = propertyStatusMap[dto.type] ?? PropertyStatus.RESERVED;
+
+    // Create contract and update property status in a transaction
+    const contract = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.contract.create({
+        data: {
+          type: dto.type,
+          propertyId: dto.propertyId,
+          clientId: dto.clientId,
+          agentId: dto.agentId ?? user.sub,
+          startDate: new Date(dto.startDate),
+          endDate: dto.endDate ? new Date(dto.endDate) : null,
+          totalAmount: dto.totalAmount,
+          paymentTerms: (dto.paymentTerms as Prisma.InputJsonValue) ?? Prisma.JsonNull,
+          documentUrl: dto.documentUrl,
+          notes: dto.notes,
+        },
+        include: {
+          property: true,
+          client: true,
+        },
+      });
+
+      await tx.property.update({
+        where: { id: dto.propertyId },
+        data: { status: newPropertyStatus },
+      });
+
+      return created;
+    });
+
+    return contract;
+  }
+
+  async findAll(
+    filter: ContractFilterDto,
+    user: AuthenticatedUser,
+  ): Promise<PaginatedResult<unknown>> {
+    const where: Prisma.ContractWhereInput = {};
+
+    if (filter.type) where.type = filter.type;
+    if (filter.status) where.status = filter.status;
+    if (filter.clientId) where.clientId = filter.clientId;
+    if (filter.propertyId) where.propertyId = filter.propertyId;
+    if (filter.agentId) where.agentId = filter.agentId;
+
+    if (filter.dateFrom || filter.dateTo) {
+      where.startDate = {};
+      if (filter.dateFrom) where.startDate.gte = new Date(filter.dateFrom);
+      if (filter.dateTo) where.startDate.lte = new Date(filter.dateTo);
+    }
+
+    if (filter.search) {
+      where.OR = [
+        { notes: { contains: filter.search, mode: 'insensitive' } },
+        { property: { title: { contains: filter.search, mode: 'insensitive' } } },
+        { client: { firstName: { contains: filter.search, mode: 'insensitive' } } },
+        { client: { lastName: { contains: filter.search, mode: 'insensitive' } } },
+      ];
+    }
+
+    // Agent role: only own contracts
+    const isAgent =
+      user.roles && !user.roles.includes('admin') && !user.roles.includes('manager');
+    if (isAgent) {
+      where.agentId = user.sub;
+    }
+
+    const orderBy: Prisma.ContractOrderByWithRelationInput = {};
+    const sortField = filter.sortBy ?? 'createdAt';
+    if (['createdAt', 'startDate', 'endDate', 'totalAmount'].includes(sortField)) {
+      orderBy[sortField as keyof Prisma.ContractOrderByWithRelationInput] =
+        filter.sortOrder ?? 'desc';
+    }
+
+    const [data, total] = await Promise.all([
+      this.prisma.contract.findMany({
+        where,
+        orderBy,
+        skip: filter.skip,
+        take: filter.limit,
+        include: {
+          property: { select: { id: true, title: true, type: true, status: true, city: true } },
+          client: { select: { id: true, firstName: true, lastName: true, phone: true } },
+          _count: { select: { invoices: true } },
+        },
+      }),
+      this.prisma.contract.count({ where }),
+    ]);
+
+    return paginate(data, total, filter);
+  }
+
+  async findOne(id: string, user: AuthenticatedUser) {
+    const contract = await this.prisma.contract.findUnique({
+      where: { id },
+      include: {
+        property: true,
+        client: true,
+        invoices: { orderBy: { dueDate: 'asc' } },
+      },
+    });
+
+    if (!contract) {
+      throw new NotFoundException(`Contract ${id} not found`);
+    }
+
+    // Agent can only view own contracts
+    const isAgent =
+      user.roles && !user.roles.includes('admin') && !user.roles.includes('manager');
+    if (isAgent && contract.agentId !== user.sub) {
+      throw new ForbiddenException('You can only view your own contracts');
+    }
+
+    return contract;
+  }
+
+  async update(id: string, dto: UpdateContractDto) {
+    const existing = await this.prisma.contract.findUnique({ where: { id } });
+    if (!existing) {
+      throw new NotFoundException(`Contract ${id} not found`);
+    }
+
+    return this.prisma.contract.update({
+      where: { id },
+      data: {
+        ...(dto.type !== undefined && { type: dto.type }),
+        ...(dto.agentId !== undefined && { agentId: dto.agentId }),
+        ...(dto.startDate !== undefined && { startDate: new Date(dto.startDate) }),
+        ...(dto.endDate !== undefined && { endDate: new Date(dto.endDate) }),
+        ...(dto.totalAmount !== undefined && { totalAmount: dto.totalAmount }),
+        ...(dto.paymentTerms !== undefined && { paymentTerms: (dto.paymentTerms as Prisma.InputJsonValue) ?? Prisma.JsonNull }),
+        ...(dto.documentUrl !== undefined && { documentUrl: dto.documentUrl }),
+        ...(dto.notes !== undefined && { notes: dto.notes }),
+      },
+      include: {
+        property: true,
+        client: true,
+      },
+    });
+  }
+
+  async changeStatus(id: string, dto: ChangeContractStatusDto) {
+    const contract = await this.prisma.contract.findUnique({
+      where: { id },
+      include: { property: true },
+    });
+
+    if (!contract) {
+      throw new NotFoundException(`Contract ${id} not found`);
+    }
+
+    // Validate status transitions
+    const validTransitions: Record<string, ContractStatus[]> = {
+      DRAFT: [ContractStatus.ACTIVE, ContractStatus.CANCELLED],
+      ACTIVE: [ContractStatus.COMPLETED, ContractStatus.CANCELLED, ContractStatus.EXPIRED],
+      COMPLETED: [],
+      CANCELLED: [],
+      EXPIRED: [ContractStatus.ACTIVE],
+    };
+
+    const allowed = validTransitions[contract.status] ?? [];
+    if (!allowed.includes(dto.status)) {
+      throw new BadRequestException(
+        `Cannot transition from ${contract.status} to ${dto.status}`,
+      );
+    }
+
+    // If cancelling/completing, restore property to AVAILABLE
+    const restoreStatuses: ContractStatus[] = [ContractStatus.CANCELLED, ContractStatus.EXPIRED];
+
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const result = await tx.contract.update({
+        where: { id },
+        data: { status: dto.status },
+        include: { property: true, client: true },
+      });
+
+      if (restoreStatuses.includes(dto.status)) {
+        await tx.property.update({
+          where: { id: contract.propertyId },
+          data: { status: PropertyStatus.AVAILABLE },
+        });
+      }
+
+      return result;
+    });
+
+    return updated;
+  }
+
+  async findContractInvoices(contractId: string) {
+    const contract = await this.prisma.contract.findUnique({
+      where: { id: contractId },
+    });
+
+    if (!contract) {
+      throw new NotFoundException(`Contract ${contractId} not found`);
+    }
+
+    return this.prisma.invoice.findMany({
+      where: { contractId },
+      orderBy: { dueDate: 'asc' },
+    });
+  }
+
+  async generateInvoices(contractId: string, dto: GenerateInvoicesDto) {
+    const contract = await this.prisma.contract.findUnique({
+      where: { id: contractId },
+      include: { invoices: true },
+    });
+
+    if (!contract) {
+      throw new NotFoundException(`Contract ${contractId} not found`);
+    }
+
+    if (contract.status === ContractStatus.CANCELLED) {
+      throw new BadRequestException('Cannot generate invoices for a cancelled contract');
+    }
+
+    const paymentTerms = contract.paymentTerms as Record<string, unknown> | null;
+    const installments = (paymentTerms?.installments as number) ?? 1;
+    const totalAmount = Number(contract.totalAmount);
+    const installmentAmount = Math.round((totalAmount / installments) * 100) / 100;
+
+    const startDate = new Date(contract.startDate);
+    const existingCount = contract.invoices.length;
+
+    const invoices: Prisma.InvoiceCreateManyInput[] = [];
+    for (let i = existingCount; i < installments; i++) {
+      const dueDate = new Date(startDate);
+      dueDate.setMonth(dueDate.getMonth() + i);
+
+      // Handle remainder on last installment
+      const isLast = i === installments - 1;
+      const amount = isLast
+        ? totalAmount - installmentAmount * (installments - 1)
+        : installmentAmount;
+
+      invoices.push({
+        contractId,
+        invoiceNumber: `INV-${contractId.slice(0, 8).toUpperCase()}-${String(i + 1).padStart(3, '0')}`,
+        amount,
+        dueDate,
+        status: InvoiceStatus.PENDING,
+        paymentMethod: dto.paymentMethod ?? null,
+      });
+    }
+
+    if (invoices.length === 0) {
+      throw new BadRequestException(
+        'All invoices have already been generated for this contract',
+      );
+    }
+
+    await this.prisma.invoice.createMany({ data: invoices });
+
+    return this.prisma.invoice.findMany({
+      where: { contractId },
+      orderBy: { dueDate: 'asc' },
+    });
+  }
+
+  async getStats(user: AuthenticatedUser) {
+    const agentFilter: Prisma.ContractWhereInput = {};
+    const isAgent =
+      user.roles && !user.roles.includes('admin') && !user.roles.includes('manager');
+    if (isAgent) {
+      agentFilter.agentId = user.sub;
+    }
+
+    const [total, byStatus, byType, totalValue] = await Promise.all([
+      this.prisma.contract.count({ where: agentFilter }),
+      this.prisma.contract.groupBy({
+        by: ['status'],
+        _count: { id: true },
+        where: agentFilter,
+      }),
+      this.prisma.contract.groupBy({
+        by: ['type'],
+        _count: { id: true },
+        where: agentFilter,
+      }),
+      this.prisma.contract.aggregate({
+        _sum: { totalAmount: true },
+        where: { ...agentFilter, status: { in: [ContractStatus.ACTIVE, ContractStatus.COMPLETED] } },
+      }),
+    ]);
+
+    return {
+      total,
+      byStatus: Object.fromEntries(byStatus.map((s) => [s.status, s._count.id])),
+      byType: Object.fromEntries(byType.map((t) => [t.type, t._count.id])),
+      totalValue: totalValue._sum.totalAmount ?? 0,
+    };
+  }
+
+  async getExpiring(daysAhead = 30, user: AuthenticatedUser) {
+    const now = new Date();
+    const future = new Date();
+    future.setDate(future.getDate() + daysAhead);
+
+    const where: Prisma.ContractWhereInput = {
+      status: ContractStatus.ACTIVE,
+      endDate: { gte: now, lte: future },
+    };
+
+    const isAgent =
+      user.roles && !user.roles.includes('admin') && !user.roles.includes('manager');
+    if (isAgent) {
+      where.agentId = user.sub;
+    }
+
+    return this.prisma.contract.findMany({
+      where,
+      orderBy: { endDate: 'asc' },
+      include: {
+        property: { select: { id: true, title: true, city: true } },
+        client: { select: { id: true, firstName: true, lastName: true, phone: true } },
+      },
+    });
+  }
+}

--- a/src/contracts/dto/change-status.dto.ts
+++ b/src/contracts/dto/change-status.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { ContractStatus } from '@prisma/client';
+
+export class ChangeContractStatusDto {
+  @ApiProperty({ enum: ContractStatus, description: 'New contract status' })
+  @IsEnum(ContractStatus)
+  status: ContractStatus;
+}

--- a/src/contracts/dto/create-contract.dto.ts
+++ b/src/contracts/dto/create-contract.dto.ts
@@ -1,0 +1,68 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  IsDateString,
+  IsNumber,
+  Min,
+  IsObject,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ContractType } from '@prisma/client';
+
+export class CreateContractDto {
+  @ApiProperty({ enum: ContractType, description: 'Contract type' })
+  @IsEnum(ContractType)
+  type: ContractType;
+
+  @ApiProperty({ description: 'Property ID' })
+  @IsUUID()
+  @IsNotEmpty()
+  propertyId: string;
+
+  @ApiProperty({ description: 'Client ID' })
+  @IsUUID()
+  @IsNotEmpty()
+  clientId: string;
+
+  @ApiPropertyOptional({ description: 'Agent ID' })
+  @IsOptional()
+  @IsUUID()
+  agentId?: string;
+
+  @ApiProperty({ description: 'Contract start date (ISO 8601)' })
+  @IsDateString()
+  startDate: string;
+
+  @ApiPropertyOptional({ description: 'Contract end date (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @ApiProperty({ description: 'Total contract amount', minimum: 0 })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  totalAmount: number;
+
+  @ApiPropertyOptional({
+    description: 'Payment terms (JSON: installments, frequency, etc.)',
+    example: { installments: 12, frequency: 'monthly' },
+  })
+  @IsOptional()
+  @IsObject()
+  paymentTerms?: Record<string, unknown>;
+
+  @ApiPropertyOptional({ description: 'Document URL' })
+  @IsOptional()
+  @IsString()
+  documentUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Notes' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/src/contracts/dto/filter-contract.dto.ts
+++ b/src/contracts/dto/filter-contract.dto.ts
@@ -1,0 +1,52 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsUUID, IsDateString, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ContractType, ContractStatus } from '@prisma/client';
+import { PaginationDto } from '../../common/dto/pagination.dto.js';
+
+export class ContractFilterDto extends PaginationDto {
+  @ApiPropertyOptional({ enum: ContractType })
+  @IsOptional()
+  @IsEnum(ContractType)
+  type?: ContractType;
+
+  @ApiPropertyOptional({ enum: ContractStatus })
+  @IsOptional()
+  @IsEnum(ContractStatus)
+  status?: ContractStatus;
+
+  @ApiPropertyOptional({ description: 'Filter by client ID' })
+  @IsOptional()
+  @IsUUID()
+  clientId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by property ID' })
+  @IsOptional()
+  @IsUUID()
+  propertyId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by agent ID' })
+  @IsOptional()
+  @IsString()
+  agentId?: string;
+
+  @ApiPropertyOptional({ description: 'Start date from (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Start date to (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @ApiPropertyOptional({ description: 'Sort by field', enum: ['createdAt', 'startDate', 'endDate', 'totalAmount'] })
+  @IsOptional()
+  @IsString()
+  sortBy?: string = 'createdAt';
+
+  @ApiPropertyOptional({ description: 'Sort direction', enum: ['asc', 'desc'] })
+  @IsOptional()
+  @IsString()
+  sortOrder?: 'asc' | 'desc' = 'desc';
+}

--- a/src/contracts/dto/generate-invoices.dto.ts
+++ b/src/contracts/dto/generate-invoices.dto.ts
@@ -1,0 +1,10 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import { PaymentMethod } from '@prisma/client';
+
+export class GenerateInvoicesDto {
+  @ApiPropertyOptional({ enum: PaymentMethod, description: 'Default payment method for generated invoices' })
+  @IsOptional()
+  @IsEnum(PaymentMethod)
+  paymentMethod?: PaymentMethod;
+}

--- a/src/contracts/dto/update-contract.dto.ts
+++ b/src/contracts/dto/update-contract.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateContractDto } from './create-contract.dto.js';
+
+export class UpdateContractDto extends PartialType(CreateContractDto) {}


### PR DESCRIPTION
## Summary
- Full Contracts CRUD API with role-based access (admin/manager create/edit, agents view-only own)
- Status transitions with validation (DRAFT → ACTIVE → COMPLETED/CANCELLED/EXPIRED)
- Auto-updates property status on contract creation (AVAILABLE → SOLD/RENTED) and cancellation (→ AVAILABLE)
- Auto-generates invoice schedules from payment terms (installments, remainder handling)
- Filtering by type, status, client, property, agent, date range + search, pagination, sorting
- Stats endpoint (total, by status, by type, total value) and expiring contracts alert
- 22 unit tests (controller + service) all passing

## Endpoints
| Method | Path | Access |
|--------|------|--------|
| POST | /api/contracts | admin, manager |
| GET | /api/contracts | all (agent-scoped) |
| GET | /api/contracts/stats | all (agent-scoped) |
| GET | /api/contracts/expiring | all (agent-scoped) |
| GET | /api/contracts/:id | all (agent-scoped) |
| PUT | /api/contracts/:id | admin, manager |
| PATCH | /api/contracts/:id/status | admin, manager |
| GET | /api/contracts/:id/invoices | all |
| POST | /api/contracts/:id/generate-invoices | admin, manager |

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 22 unit tests pass
- [ ] E2E testing with running database
- [ ] Verify Swagger docs render correctly

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)