### PR TITLE
feat(invoices): Invoices Module — Backend CRUD & Payments (#10)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { PrismaModule } from './prisma/prisma.module.js';
 import { ClientsModule } from './clients/clients.module.js';
 import { PropertiesModule } from './properties/properties.module.js';
 import { ContractsModule } from './contracts/contracts.module.js';
+import { InvoicesModule } from './invoices/invoices.module.js';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { ContractsModule } from './contracts/contracts.module.js';
     ClientsModule,
     PropertiesModule,
     ContractsModule,
+    InvoicesModule,
   ],
   providers: [
     {

--- a/src/invoices/dto/create-invoice.dto.ts
+++ b/src/invoices/dto/create-invoice.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsDateString,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+} from 'class-validator';
+
+export class CreateInvoiceDto {
+  @ApiProperty({ description: 'Contract ID this invoice belongs to' })
+  @IsNotEmpty()
+  @IsUUID()
+  contractId: string;
+
+  @ApiProperty({ description: 'Invoice amount', example: 15000.0 })
+  @IsNotEmpty()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  amount: number;
+
+  @ApiProperty({ description: 'Payment due date (ISO 8601)', example: '2026-04-01' })
+  @IsNotEmpty()
+  @IsDateString()
+  dueDate: string;
+
+  @ApiPropertyOptional({ description: 'Additional notes' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/src/invoices/dto/invoice-filter.dto.ts
+++ b/src/invoices/dto/invoice-filter.dto.ts
@@ -1,0 +1,51 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsBooleanString,
+  IsDateString,
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
+import { InvoiceStatus } from '@prisma/client';
+import { PaginationDto } from '../../common/dto/pagination.dto.js';
+
+export class InvoiceFilterDto extends PaginationDto {
+  @ApiPropertyOptional({ description: 'Filter by invoice status', enum: InvoiceStatus })
+  @IsOptional()
+  @IsEnum(InvoiceStatus)
+  status?: InvoiceStatus;
+
+  @ApiPropertyOptional({ description: 'Filter by contract ID' })
+  @IsOptional()
+  @IsUUID()
+  contractId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter from due date (ISO 8601)', example: '2026-01-01' })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Filter to due date (ISO 8601)', example: '2026-12-31' })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @ApiPropertyOptional({ description: 'Filter overdue invoices only', example: 'true' })
+  @IsOptional()
+  @IsBooleanString()
+  overdue?: string;
+
+  @ApiPropertyOptional({
+    description: 'Sort field',
+    enum: ['createdAt', 'dueDate', 'amount'],
+  })
+  @IsOptional()
+  @IsString()
+  sortBy?: 'createdAt' | 'dueDate' | 'amount' = 'dueDate';
+
+  @ApiPropertyOptional({ description: 'Sort direction', enum: ['asc', 'desc'] })
+  @IsOptional()
+  @IsString()
+  sortOrder?: 'asc' | 'desc' = 'asc';
+}

--- a/src/invoices/dto/record-payment.dto.ts
+++ b/src/invoices/dto/record-payment.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { PaymentMethod } from '@prisma/client';
+
+export class RecordPaymentDto {
+  @ApiProperty({
+    description: 'Date the payment was received (ISO 8601)',
+    example: '2026-03-25',
+  })
+  @IsNotEmpty()
+  @IsDateString()
+  paidDate: string;
+
+  @ApiProperty({
+    description: 'Payment method used',
+    enum: PaymentMethod,
+    example: PaymentMethod.BANK_TRANSFER,
+  })
+  @IsNotEmpty()
+  @IsEnum(PaymentMethod)
+  paymentMethod: PaymentMethod;
+
+  @ApiPropertyOptional({ description: 'Payment notes or reference number' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/src/invoices/dto/update-invoice.dto.ts
+++ b/src/invoices/dto/update-invoice.dto.ts
@@ -1,0 +1,26 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class UpdateInvoiceDto {
+  @ApiPropertyOptional({ description: 'Invoice amount', example: 15000.0 })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  amount?: number;
+
+  @ApiPropertyOptional({ description: 'Payment due date (ISO 8601)', example: '2026-04-15' })
+  @IsOptional()
+  @IsDateString()
+  dueDate?: string;
+
+  @ApiPropertyOptional({ description: 'Additional notes' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/src/invoices/invoices.controller.spec.ts
+++ b/src/invoices/invoices.controller.spec.ts
@@ -1,0 +1,184 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InvoicesController } from './invoices.controller.js';
+import { InvoicesService } from './invoices.service.js';
+import { InvoiceStatus, PaymentMethod } from '@prisma/client';
+
+const mockService = {
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  recordPayment: jest.fn(),
+  cancel: jest.fn(),
+  findOverdue: jest.fn(),
+  findUpcoming: jest.fn(),
+  getStats: jest.fn(),
+};
+
+const sampleInvoice = {
+  id: 'invoice-uuid-001',
+  contractId: 'contract-uuid-001',
+  invoiceNumber: 'INV-2026-0001',
+  amount: 50000,
+  dueDate: new Date('2026-04-01'),
+  paidDate: null,
+  status: InvoiceStatus.PENDING,
+  paymentMethod: null,
+  notes: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('InvoicesController', () => {
+  let controller: InvoicesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InvoicesController],
+      providers: [{ provide: InvoicesService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get<InvoicesController>(InvoicesController);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create an invoice', async () => {
+      mockService.create.mockResolvedValue(sampleInvoice);
+
+      const dto = {
+        contractId: 'contract-uuid-001',
+        amount: 50000,
+        dueDate: '2026-04-01',
+      };
+
+      const result = await controller.create(dto as any);
+      expect(result).toEqual(sampleInvoice);
+      expect(mockService.create).toHaveBeenCalledWith(dto);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return paginated invoices', async () => {
+      const paginated = {
+        data: [sampleInvoice],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      };
+      mockService.findAll.mockResolvedValue(paginated);
+
+      const result = await controller.findAll({} as any);
+      expect(result).toEqual(paginated);
+      expect(mockService.findAll).toHaveBeenCalledWith({});
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return payment statistics', async () => {
+      const stats = {
+        total: 20,
+        totalDue: 200000,
+        totalCollected: 150000,
+        totalOverdue: 30000,
+        byStatus: {},
+      };
+      mockService.getStats.mockResolvedValue(stats);
+
+      const result = await controller.getStats();
+      expect(result.total).toBe(20);
+      expect(result.totalCollected).toBe(150000);
+      expect(mockService.getStats).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findOverdue', () => {
+    it('should return overdue invoices', async () => {
+      const overdueList = [{ ...sampleInvoice, dueDate: new Date('2025-01-01') }];
+      mockService.findOverdue.mockResolvedValue(overdueList);
+
+      const result = await controller.findOverdue();
+      expect(result).toEqual(overdueList);
+      expect(mockService.findOverdue).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findUpcoming', () => {
+    it('should return upcoming invoices with default 30 days', async () => {
+      mockService.findUpcoming.mockResolvedValue([sampleInvoice]);
+
+      const result = await controller.findUpcoming(undefined);
+      expect(result).toHaveLength(1);
+      expect(mockService.findUpcoming).toHaveBeenCalledWith(30);
+    });
+
+    it('should pass custom days to service', async () => {
+      mockService.findUpcoming.mockResolvedValue([]);
+
+      await controller.findUpcoming('7');
+      expect(mockService.findUpcoming).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return an invoice by ID', async () => {
+      const withContract = {
+        ...sampleInvoice,
+        contract: { id: 'contract-uuid-001', type: 'SALE', property: {}, client: {} },
+      };
+      mockService.findOne.mockResolvedValue(withContract);
+
+      const result = await controller.findOne(sampleInvoice.id);
+      expect(result.id).toBe(sampleInvoice.id);
+      expect(mockService.findOne).toHaveBeenCalledWith(sampleInvoice.id);
+    });
+  });
+
+  describe('update', () => {
+    it('should update an invoice', async () => {
+      const updated = { ...sampleInvoice, amount: 60000 };
+      mockService.update.mockResolvedValue(updated);
+
+      const result = await controller.update(sampleInvoice.id, { amount: 60000 });
+      expect(result.amount).toBe(60000);
+      expect(mockService.update).toHaveBeenCalledWith(sampleInvoice.id, { amount: 60000 });
+    });
+  });
+
+  describe('recordPayment', () => {
+    it('should record a payment', async () => {
+      const paid = {
+        ...sampleInvoice,
+        status: InvoiceStatus.PAID,
+        paidDate: new Date('2026-03-25'),
+        paymentMethod: PaymentMethod.BANK_TRANSFER,
+      };
+      mockService.recordPayment.mockResolvedValue(paid);
+
+      const dto = {
+        paidDate: '2026-03-25',
+        paymentMethod: PaymentMethod.BANK_TRANSFER,
+      };
+
+      const result = await controller.recordPayment(sampleInvoice.id, dto as any);
+      expect(result.status).toBe(InvoiceStatus.PAID);
+      expect(mockService.recordPayment).toHaveBeenCalledWith(sampleInvoice.id, dto);
+    });
+  });
+
+  describe('cancel', () => {
+    it('should cancel an invoice', async () => {
+      const cancelled = { ...sampleInvoice, status: InvoiceStatus.CANCELLED };
+      mockService.cancel.mockResolvedValue(cancelled);
+
+      const result = await controller.cancel(sampleInvoice.id);
+      expect(result.status).toBe(InvoiceStatus.CANCELLED);
+      expect(mockService.cancel).toHaveBeenCalledWith(sampleInvoice.id);
+    });
+  });
+});

--- a/src/invoices/invoices.controller.ts
+++ b/src/invoices/invoices.controller.ts
@@ -1,0 +1,131 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { InvoicesService } from './invoices.service.js';
+import { CreateInvoiceDto } from './dto/create-invoice.dto.js';
+import { UpdateInvoiceDto } from './dto/update-invoice.dto.js';
+import { InvoiceFilterDto } from './dto/invoice-filter.dto.js';
+import { RecordPaymentDto } from './dto/record-payment.dto.js';
+import { Roles } from '../common/decorators/roles.decorator.js';
+import { AuthGuard } from '../common/guards/auth.guard.js';
+
+@ApiTags('Invoices')
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Controller('api/invoices')
+export class InvoicesController {
+  constructor(private readonly invoicesService: InvoicesService) {}
+
+  @Post()
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Create a new invoice for a contract' })
+  @ApiResponse({ status: 201, description: 'Invoice created' })
+  @ApiResponse({ status: 404, description: 'Contract not found' })
+  create(@Body() dto: CreateInvoiceDto) {
+    return this.invoicesService.create(dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List invoices with filters and pagination' })
+  @ApiResponse({ status: 200, description: 'Paginated list of invoices' })
+  findAll(@Query() filter: InvoiceFilterDto) {
+    return this.invoicesService.findAll(filter);
+  }
+
+  @Get('stats')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Get payment statistics (total due, collected, overdue)' })
+  @ApiResponse({ status: 200, description: 'Invoice statistics' })
+  getStats() {
+    return this.invoicesService.getStats();
+  }
+
+  @Get('overdue')
+  @ApiOperation({ summary: 'List all overdue invoices (pending past due date)' })
+  @ApiResponse({ status: 200, description: 'Overdue invoices' })
+  findOverdue() {
+    return this.invoicesService.findOverdue();
+  }
+
+  @Get('upcoming')
+  @ApiOperation({ summary: 'List invoices due in the next N days' })
+  @ApiQuery({
+    name: 'days',
+    required: false,
+    type: Number,
+    description: 'Days ahead to look (default: 30)',
+  })
+  @ApiResponse({ status: 200, description: 'Upcoming invoices' })
+  findUpcoming(@Query('days') days?: string) {
+    return this.invoicesService.findUpcoming(days ? Number(days) : 30);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get invoice by ID with full contract details' })
+  @ApiParam({ name: 'id', description: 'Invoice UUID' })
+  @ApiResponse({ status: 200, description: 'Invoice details' })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.invoicesService.findOne(id);
+  }
+
+  @Put(':id')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Update an invoice (amount, due date, notes)' })
+  @ApiParam({ name: 'id', description: 'Invoice UUID' })
+  @ApiResponse({ status: 200, description: 'Invoice updated' })
+  @ApiResponse({ status: 400, description: 'Cannot update paid or cancelled invoice' })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateInvoiceDto,
+  ) {
+    return this.invoicesService.update(id, dto);
+  }
+
+  @Patch(':id/pay')
+  @Roles('admin', 'manager')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Record a payment for an invoice' })
+  @ApiParam({ name: 'id', description: 'Invoice UUID' })
+  @ApiResponse({ status: 200, description: 'Payment recorded' })
+  @ApiResponse({ status: 400, description: 'Invoice already paid or cancelled' })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  recordPayment(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: RecordPaymentDto,
+  ) {
+    return this.invoicesService.recordPayment(id, dto);
+  }
+
+  @Patch(':id/cancel')
+  @Roles('admin', 'manager')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Cancel an invoice' })
+  @ApiParam({ name: 'id', description: 'Invoice UUID' })
+  @ApiResponse({ status: 200, description: 'Invoice cancelled' })
+  @ApiResponse({ status: 400, description: 'Invoice already paid or cancelled' })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  cancel(@Param('id', ParseUUIDPipe) id: string) {
+    return this.invoicesService.cancel(id);
+  }
+}

--- a/src/invoices/invoices.module.ts
+++ b/src/invoices/invoices.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { InvoicesController } from './invoices.controller.js';
+import { InvoicesService } from './invoices.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [InvoicesController],
+  providers: [InvoicesService],
+  exports: [InvoicesService],
+})
+export class InvoicesModule {}

--- a/src/invoices/invoices.service.spec.ts
+++ b/src/invoices/invoices.service.spec.ts
@@ -1,0 +1,371 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { InvoicesService } from './invoices.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { InvoiceStatus, PaymentMethod } from '@prisma/client';
+
+const mockPrisma = {
+  invoice: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    count: jest.fn(),
+    aggregate: jest.fn(),
+    groupBy: jest.fn(),
+  },
+  contract: {
+    findUnique: jest.fn(),
+  },
+};
+
+describe('InvoicesService', () => {
+  let service: InvoicesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InvoicesService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<InvoicesService>(InvoicesService);
+    jest.clearAllMocks();
+  });
+
+  const sampleContract = {
+    id: 'contract-uuid-001',
+    type: 'SALE',
+    status: 'ACTIVE',
+    totalAmount: 500000,
+  };
+
+  const sampleInvoice = {
+    id: 'invoice-uuid-001',
+    contractId: sampleContract.id,
+    invoiceNumber: 'INV-2026-0001',
+    amount: 50000,
+    dueDate: new Date('2026-04-01'),
+    paidDate: null,
+    status: InvoiceStatus.PENDING,
+    paymentMethod: null,
+    notes: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  // ─── create ──────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('should create an invoice with an auto-generated invoice number', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue(sampleContract);
+      mockPrisma.invoice.count.mockResolvedValue(0);
+      mockPrisma.invoice.create.mockResolvedValue({ ...sampleInvoice, invoiceNumber: 'INV-2026-0001' });
+
+      const result = await service.create({
+        contractId: sampleContract.id,
+        amount: 50000,
+        dueDate: '2026-04-01',
+      });
+
+      expect(result.invoiceNumber).toBe('INV-2026-0001');
+      expect(mockPrisma.invoice.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw NotFoundException when contract does not exist', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.create({ contractId: 'nonexistent', amount: 1000, dueDate: '2026-04-01' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should increment invoice number when invoices already exist for the year', async () => {
+      mockPrisma.contract.findUnique.mockResolvedValue(sampleContract);
+      mockPrisma.invoice.count.mockResolvedValue(5);
+      mockPrisma.invoice.create.mockResolvedValue({ ...sampleInvoice, invoiceNumber: 'INV-2026-0006' });
+
+      const result = await service.create({
+        contractId: sampleContract.id,
+        amount: 25000,
+        dueDate: '2026-05-01',
+      });
+
+      expect(result.invoiceNumber).toBe('INV-2026-0006');
+    });
+  });
+
+  // ─── findAll ─────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('should return paginated invoices', async () => {
+      const invoices = [{ ...sampleInvoice }];
+      mockPrisma.invoice.findMany.mockResolvedValue(invoices);
+      mockPrisma.invoice.count.mockResolvedValue(1);
+
+      const result = await service.findAll({ page: 1, limit: 20, skip: 0 } as any);
+
+      expect(result.data).toEqual(invoices);
+      expect(result.total).toBe(1);
+    });
+
+    it('should apply overdue filter', async () => {
+      mockPrisma.invoice.findMany.mockResolvedValue([]);
+      mockPrisma.invoice.count.mockResolvedValue(0);
+
+      await service.findAll({ page: 1, limit: 20, skip: 0, overdue: 'true' } as any);
+
+      const call = mockPrisma.invoice.findMany.mock.calls[0][0];
+      expect(call.where.status).toBe(InvoiceStatus.PENDING);
+      expect(call.where.dueDate).toBeDefined();
+    });
+
+    it('should filter by status', async () => {
+      mockPrisma.invoice.findMany.mockResolvedValue([]);
+      mockPrisma.invoice.count.mockResolvedValue(0);
+
+      await service.findAll({
+        page: 1,
+        limit: 20,
+        skip: 0,
+        status: InvoiceStatus.PAID,
+      } as any);
+
+      expect(mockPrisma.invoice.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: InvoiceStatus.PAID }),
+        }),
+      );
+    });
+
+    it('should filter by contractId', async () => {
+      mockPrisma.invoice.findMany.mockResolvedValue([]);
+      mockPrisma.invoice.count.mockResolvedValue(0);
+
+      await service.findAll({
+        page: 1,
+        limit: 20,
+        skip: 0,
+        contractId: sampleContract.id,
+      } as any);
+
+      expect(mockPrisma.invoice.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ contractId: sampleContract.id }),
+        }),
+      );
+    });
+  });
+
+  // ─── findOne ─────────────────────────────────────────────────────────────
+
+  describe('findOne', () => {
+    it('should return an invoice with contract details', async () => {
+      const invoiceWithContract = {
+        ...sampleInvoice,
+        contract: { ...sampleContract, property: {}, client: {} },
+      };
+      mockPrisma.invoice.findUnique.mockResolvedValue(invoiceWithContract);
+
+      const result = await service.findOne(sampleInvoice.id);
+      expect(result.id).toBe(sampleInvoice.id);
+    });
+
+    it('should throw NotFoundException when invoice does not exist', async () => {
+      mockPrisma.invoice.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── update ──────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('should update a pending invoice', async () => {
+      mockPrisma.invoice.findUnique.mockResolvedValue(sampleInvoice);
+      const updated = { ...sampleInvoice, amount: 60000 };
+      mockPrisma.invoice.update.mockResolvedValue(updated);
+
+      const result = await service.update(sampleInvoice.id, { amount: 60000 });
+      expect(result.amount).toBe(60000);
+    });
+
+    it('should throw BadRequestException when updating a paid invoice', async () => {
+      mockPrisma.invoice.findUnique.mockResolvedValue({
+        ...sampleInvoice,
+        status: InvoiceStatus.PAID,
+      });
+
+      await expect(service.update(sampleInvoice.id, { amount: 60000 })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when updating a cancelled invoice', async () => {
+      mockPrisma.invoice.findUnique.mockResolvedValue({
+        ...sampleInvoice,
+        status: InvoiceStatus.CANCELLED,
+      });
+
+      await expect(service.update(sampleInvoice.id, { notes: 'test' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  // ─── recordPayment ────────────────────────────────────────────────────────
+
+  describe('recordPayment', () => {
+    it('should mark a pending invoice as paid', async () => {
+      mockPrisma.invoice.findUnique.mockResolvedValue(sampleInvoice);
+      const paid = {
+        ...sampleInvoice,
+        status: InvoiceStatus.PAID,
+        paidDate: new Date('2026-03-25'),
+        paymentMethod: PaymentMethod.BANK_TRANSFER,
+      };
+      mockPrisma.invoice.update.mockResolvedValue(paid);
+
+      const result = await service.recordPayment(sampleInvoice.id, {
+        paidDate: '2026-03-25',
+        paymentMethod: PaymentMethod.BANK_TRANSFER,
+      });
+
+      expect(result.status).toBe(InvoiceStatus.PAID);
+      expect(result.paymentMethod).toBe(PaymentMethod.BANK_TRANSFER);
+    });
+
+    it('should throw BadRequestException when invoice is already paid', async () => {
+      mockPrisma.invoice.findUnique.mockResolvedValue({
+        ...sampleInvoice,
+        status: InvoiceStatus.PAID,
+      });
+
+      await expect(
+        service.recordPayment(sampleInvoice.id, {
+          paidDate: '2026-03-25',
+          paymentMethod: PaymentMethod.CASH,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when invoice is cancelled', async () => {
+      mockPrisma.invoice.findUnique.mockResolvedValue({
+        ...sampleInvoice,
+        status: InvoiceStatus.CANCELLED,
+      });
+
+      await expect(
+        service.recordPayment(sampleInvoice.id, {
+          paidDate: '2026-03-25',
+          paymentMethod: PaymentMethod.CASH,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── cancel ───────────────────────────────────────────────────────────────
+
+  describe('cancel', () => {
+    it('should cancel a pending invoice', async () => {
+      mockPrisma.invoice.findUnique.mockResolvedValue(sampleInvoice);
+      const cancelled = { ...sampleInvoice, status: InvoiceStatus.CANCELLED };
+      mockPrisma.invoice.update.mockResolvedValue(cancelled);
+
+      const result = await service.cancel(sampleInvoice.id);
+      expect(result.status).toBe(InvoiceStatus.CANCELLED);
+    });
+
+    it('should throw BadRequestException when cancelling a paid invoice', async () => {
+      mockPrisma.invoice.findUnique.mockResolvedValue({
+        ...sampleInvoice,
+        status: InvoiceStatus.PAID,
+      });
+
+      await expect(service.cancel(sampleInvoice.id)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when invoice is already cancelled', async () => {
+      mockPrisma.invoice.findUnique.mockResolvedValue({
+        ...sampleInvoice,
+        status: InvoiceStatus.CANCELLED,
+      });
+
+      await expect(service.cancel(sampleInvoice.id)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── findOverdue ──────────────────────────────────────────────────────────
+
+  describe('findOverdue', () => {
+    it('should return overdue pending invoices', async () => {
+      const overdueInvoice = {
+        ...sampleInvoice,
+        dueDate: new Date('2025-01-01'),
+      };
+      mockPrisma.invoice.findMany.mockResolvedValue([overdueInvoice]);
+
+      const result = await service.findOverdue();
+
+      expect(result).toHaveLength(1);
+      const call = mockPrisma.invoice.findMany.mock.calls[0][0];
+      expect(call.where.status).toBe(InvoiceStatus.PENDING);
+      expect(call.where.dueDate.lt).toBeInstanceOf(Date);
+    });
+  });
+
+  // ─── findUpcoming ─────────────────────────────────────────────────────────
+
+  describe('findUpcoming', () => {
+    it('should return invoices due in the next 30 days by default', async () => {
+      mockPrisma.invoice.findMany.mockResolvedValue([sampleInvoice]);
+
+      const result = await service.findUpcoming();
+
+      expect(result).toHaveLength(1);
+      const call = mockPrisma.invoice.findMany.mock.calls[0][0];
+      expect(call.where.status).toBe(InvoiceStatus.PENDING);
+      expect(call.where.dueDate.gte).toBeInstanceOf(Date);
+      expect(call.where.dueDate.lte).toBeInstanceOf(Date);
+    });
+
+    it('should accept a custom days parameter', async () => {
+      mockPrisma.invoice.findMany.mockResolvedValue([]);
+
+      await service.findUpcoming(7);
+
+      const call = mockPrisma.invoice.findMany.mock.calls[0][0];
+      const diffDays =
+        (call.where.dueDate.lte.getTime() - call.where.dueDate.gte.getTime()) /
+        (1000 * 60 * 60 * 24);
+      expect(Math.round(diffDays)).toBe(7);
+    });
+  });
+
+  // ─── getStats ─────────────────────────────────────────────────────────────
+
+  describe('getStats', () => {
+    it('should return aggregated payment statistics', async () => {
+      mockPrisma.invoice.count.mockResolvedValue(20);
+      mockPrisma.invoice.aggregate
+        .mockResolvedValueOnce({ _sum: { amount: 200000 } })  // totalDue
+        .mockResolvedValueOnce({ _sum: { amount: 150000 } })  // totalCollected
+        .mockResolvedValueOnce({ _sum: { amount: 30000 } });  // totalOverdue
+      mockPrisma.invoice.groupBy.mockResolvedValue([
+        { status: InvoiceStatus.PENDING, _count: { id: 8 }, _sum: { amount: 200000 } },
+        { status: InvoiceStatus.PAID, _count: { id: 10 }, _sum: { amount: 150000 } },
+        { status: InvoiceStatus.CANCELLED, _count: { id: 2 }, _sum: { amount: 50000 } },
+      ]);
+
+      const stats = await service.getStats();
+
+      expect(stats.total).toBe(20);
+      expect(stats.totalDue).toBe(200000);
+      expect(stats.totalCollected).toBe(150000);
+      expect(stats.totalOverdue).toBe(30000);
+      expect(stats.byStatus).toHaveProperty(InvoiceStatus.PENDING);
+      expect(stats.byStatus[InvoiceStatus.PAID].count).toBe(10);
+    });
+  });
+});

--- a/src/invoices/invoices.service.ts
+++ b/src/invoices/invoices.service.ts
@@ -1,0 +1,321 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma, InvoiceStatus } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CreateInvoiceDto } from './dto/create-invoice.dto.js';
+import { UpdateInvoiceDto } from './dto/update-invoice.dto.js';
+import { InvoiceFilterDto } from './dto/invoice-filter.dto.js';
+import { RecordPaymentDto } from './dto/record-payment.dto.js';
+import { paginate, PaginatedResult } from '../common/dto/pagination.dto.js';
+
+@Injectable()
+export class InvoicesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  private async ensureInvoiceExists(id: string) {
+    const invoice = await this.prisma.invoice.findUnique({ where: { id } });
+    if (!invoice) {
+      throw new NotFoundException(`Invoice with ID "${id}" not found`);
+    }
+    return invoice;
+  }
+
+  /**
+   * Generate a sequential invoice number in the format INV-YYYY-NNNN.
+   * Counts existing invoices for the current year and increments.
+   */
+  private async generateInvoiceNumber(): Promise<string> {
+    const year = new Date().getFullYear();
+    const yearStart = new Date(`${year}-01-01T00:00:00.000Z`);
+    const yearEnd = new Date(`${year + 1}-01-01T00:00:00.000Z`);
+
+    const count = await this.prisma.invoice.count({
+      where: {
+        createdAt: { gte: yearStart, lt: yearEnd },
+      },
+    });
+
+    const sequence = String(count + 1).padStart(4, '0');
+    return `INV-${year}-${sequence}`;
+  }
+
+  // ─── CRUD ────────────────────────────────────────────────────────────────
+
+  async create(dto: CreateInvoiceDto) {
+    // Validate contract exists
+    const contract = await this.prisma.contract.findUnique({
+      where: { id: dto.contractId },
+    });
+    if (!contract) {
+      throw new NotFoundException(`Contract with ID "${dto.contractId}" not found`);
+    }
+
+    const invoiceNumber = await this.generateInvoiceNumber();
+
+    return this.prisma.invoice.create({
+      data: {
+        contractId: dto.contractId,
+        invoiceNumber,
+        amount: dto.amount,
+        dueDate: new Date(dto.dueDate),
+        notes: dto.notes,
+        status: InvoiceStatus.PENDING,
+      },
+      include: {
+        contract: {
+          select: {
+            id: true,
+            type: true,
+            status: true,
+            totalAmount: true,
+            property: { select: { id: true, title: true, city: true } },
+            client: { select: { id: true, firstName: true, lastName: true } },
+          },
+        },
+      },
+    });
+  }
+
+  async findAll(filter: InvoiceFilterDto): Promise<PaginatedResult<unknown>> {
+    const where: Prisma.InvoiceWhereInput = {};
+
+    if (filter.status) where.status = filter.status;
+    if (filter.contractId) where.contractId = filter.contractId;
+
+    if (filter.dateFrom || filter.dateTo) {
+      where.dueDate = {};
+      if (filter.dateFrom) where.dueDate.gte = new Date(filter.dateFrom);
+      if (filter.dateTo) where.dueDate.lte = new Date(filter.dateTo);
+    }
+
+    // Overdue: pending invoices whose due date has passed
+    if (filter.overdue === 'true') {
+      where.status = InvoiceStatus.PENDING;
+      where.dueDate = { ...(where.dueDate as object), lt: new Date() };
+    }
+
+    if (filter.search) {
+      where.OR = [
+        { invoiceNumber: { contains: filter.search, mode: 'insensitive' } },
+        { notes: { contains: filter.search, mode: 'insensitive' } },
+        {
+          contract: {
+            property: { title: { contains: filter.search, mode: 'insensitive' } },
+          },
+        },
+      ];
+    }
+
+    const sortField = filter.sortBy ?? 'dueDate';
+    const allowedSortFields = ['createdAt', 'dueDate', 'amount'];
+    const orderBy: Prisma.InvoiceOrderByWithRelationInput = allowedSortFields.includes(sortField)
+      ? { [sortField]: filter.sortOrder ?? 'asc' }
+      : { dueDate: 'asc' };
+
+    const [data, total] = await Promise.all([
+      this.prisma.invoice.findMany({
+        where,
+        orderBy,
+        skip: filter.skip,
+        take: filter.limit,
+        include: {
+          contract: {
+            select: {
+              id: true,
+              type: true,
+              status: true,
+              property: { select: { id: true, title: true, city: true } },
+              client: { select: { id: true, firstName: true, lastName: true } },
+            },
+          },
+        },
+      }),
+      this.prisma.invoice.count({ where }),
+    ]);
+
+    return paginate(data, total, filter);
+  }
+
+  async findOne(id: string) {
+    const invoice = await this.prisma.invoice.findUnique({
+      where: { id },
+      include: {
+        contract: {
+          include: {
+            property: { select: { id: true, title: true, type: true, city: true, address: true } },
+            client: { select: { id: true, firstName: true, lastName: true, phone: true, email: true } },
+          },
+        },
+      },
+    });
+
+    if (!invoice) {
+      throw new NotFoundException(`Invoice with ID "${id}" not found`);
+    }
+
+    return invoice;
+  }
+
+  async update(id: string, dto: UpdateInvoiceDto) {
+    const invoice = await this.ensureInvoiceExists(id);
+
+    if (invoice.status === InvoiceStatus.PAID) {
+      throw new BadRequestException('Cannot update a paid invoice');
+    }
+
+    if (invoice.status === InvoiceStatus.CANCELLED) {
+      throw new BadRequestException('Cannot update a cancelled invoice');
+    }
+
+    return this.prisma.invoice.update({
+      where: { id },
+      data: {
+        ...(dto.amount !== undefined && { amount: dto.amount }),
+        ...(dto.dueDate !== undefined && { dueDate: new Date(dto.dueDate) }),
+        ...(dto.notes !== undefined && { notes: dto.notes }),
+      },
+    });
+  }
+
+  // ─── Status transitions ───────────────────────────────────────────────────
+
+  async recordPayment(id: string, dto: RecordPaymentDto) {
+    const invoice = await this.ensureInvoiceExists(id);
+
+    if (invoice.status === InvoiceStatus.PAID) {
+      throw new BadRequestException('Invoice is already paid');
+    }
+
+    if (invoice.status === InvoiceStatus.CANCELLED) {
+      throw new BadRequestException('Cannot pay a cancelled invoice');
+    }
+
+    return this.prisma.invoice.update({
+      where: { id },
+      data: {
+        status: InvoiceStatus.PAID,
+        paidDate: new Date(dto.paidDate),
+        paymentMethod: dto.paymentMethod,
+        notes: dto.notes !== undefined ? dto.notes : invoice.notes,
+      },
+    });
+  }
+
+  async cancel(id: string) {
+    const invoice = await this.ensureInvoiceExists(id);
+
+    if (invoice.status === InvoiceStatus.PAID) {
+      throw new BadRequestException('Cannot cancel a paid invoice');
+    }
+
+    if (invoice.status === InvoiceStatus.CANCELLED) {
+      throw new BadRequestException('Invoice is already cancelled');
+    }
+
+    return this.prisma.invoice.update({
+      where: { id },
+      data: { status: InvoiceStatus.CANCELLED },
+    });
+  }
+
+  // ─── Specialised queries ──────────────────────────────────────────────────
+
+  async findOverdue(): Promise<unknown[]> {
+    return this.prisma.invoice.findMany({
+      where: {
+        status: InvoiceStatus.PENDING,
+        dueDate: { lt: new Date() },
+      },
+      orderBy: { dueDate: 'asc' },
+      include: {
+        contract: {
+          select: {
+            id: true,
+            type: true,
+            property: { select: { id: true, title: true, city: true } },
+            client: { select: { id: true, firstName: true, lastName: true, phone: true } },
+          },
+        },
+      },
+    });
+  }
+
+  async findUpcoming(days = 30): Promise<unknown[]> {
+    const now = new Date();
+    const future = new Date();
+    future.setDate(future.getDate() + days);
+
+    return this.prisma.invoice.findMany({
+      where: {
+        status: InvoiceStatus.PENDING,
+        dueDate: { gte: now, lte: future },
+      },
+      orderBy: { dueDate: 'asc' },
+      include: {
+        contract: {
+          select: {
+            id: true,
+            type: true,
+            property: { select: { id: true, title: true, city: true } },
+            client: { select: { id: true, firstName: true, lastName: true, phone: true } },
+          },
+        },
+      },
+    });
+  }
+
+  async getStats() {
+    const now = new Date();
+
+    const [
+      totalInvoices,
+      totalDue,
+      totalCollected,
+      totalOverdue,
+      byStatus,
+    ] = await Promise.all([
+      this.prisma.invoice.count(),
+      // Total pending (not yet paid, not cancelled)
+      this.prisma.invoice.aggregate({
+        _sum: { amount: true },
+        where: { status: InvoiceStatus.PENDING },
+      }),
+      // Total collected (paid)
+      this.prisma.invoice.aggregate({
+        _sum: { amount: true },
+        where: { status: InvoiceStatus.PAID },
+      }),
+      // Total overdue amount
+      this.prisma.invoice.aggregate({
+        _sum: { amount: true },
+        where: {
+          status: InvoiceStatus.PENDING,
+          dueDate: { lt: now },
+        },
+      }),
+      this.prisma.invoice.groupBy({
+        by: ['status'],
+        _count: { id: true },
+        _sum: { amount: true },
+      }),
+    ]);
+
+    return {
+      total: totalInvoices,
+      totalDue: totalDue._sum.amount ?? 0,
+      totalCollected: totalCollected._sum.amount ?? 0,
+      totalOverdue: totalOverdue._sum.amount ?? 0,
+      byStatus: Object.fromEntries(
+        byStatus.map((s) => [
+          s.status,
+          { count: s._count.id, amount: s._sum.amount ?? 0 },
+        ]),
+      ),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Implements full Invoices CRUD module as specified in issue #10 (assigned to Backend Agent 2)
- Auto-generates sequential invoice numbers in `INV-YYYY-NNNN` format
- Full payment lifecycle: PENDING → PAID / CANCELLED with validation guards

## Endpoints implemented

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/invoices` | Create invoice (admin/manager) |
| GET | `/api/invoices` | List with filters & pagination |
| GET | `/api/invoices/stats` | Payment statistics |
| GET | `/api/invoices/overdue` | Pending past-due invoices |
| GET | `/api/invoices/upcoming` | Due in next N days |
| GET | `/api/invoices/:id` | Full detail with contract/property/client |
| PUT | `/api/invoices/:id` | Update amount/dueDate/notes |
| PATCH | `/api/invoices/:id/pay` | Record payment with method & date |
| PATCH | `/api/invoices/:id/cancel` | Cancel invoice |

## Service logic

- Invoice number auto-generation (`INV-YYYY-NNNN`) based on year-scoped count
- Status transition guards: cannot update/cancel a PAID invoice; cannot pay a CANCELLED invoice
- Overdue filter: PENDING invoices with `dueDate < now`
- Stats: `totalDue`, `totalCollected`, `totalOverdue`, `byStatus` breakdown
- All routes protected by `AuthGuard`; mutating routes restricted to `admin`/`manager` roles

## Test plan

- [x] 33 unit tests (service: 22, controller: 11) — all passing
- [x] Full test suite (91 tests across 7 suites) — all passing
- [ ] E2E tests to be added in issue #31 (Comprehensive Testing Suite)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)