### PR TITLE
feat(leads): Leads Module — CRUD, Pipeline & Activities API (#8)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { ClientsModule } from './clients/clients.module.js';
 import { PropertiesModule } from './properties/properties.module.js';
 import { ContractsModule } from './contracts/contracts.module.js';
 import { InvoicesModule } from './invoices/invoices.module.js';
+import { LeadsModule } from './leads/leads.module.js';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { InvoicesModule } from './invoices/invoices.module.js';
     PropertiesModule,
     ContractsModule,
     InvoicesModule,
+    LeadsModule,
   ],
   providers: [
     {

--- a/src/leads/dto/assign-agent.dto.ts
+++ b/src/leads/dto/assign-agent.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class AssignAgentDto {
+  @ApiProperty({ description: 'Agent user ID to assign' })
+  @IsNotEmpty()
+  @IsUUID()
+  agentId: string;
+}

--- a/src/leads/dto/change-lead-status.dto.ts
+++ b/src/leads/dto/change-lead-status.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { LeadStatus } from '@prisma/client';
+
+export class ChangeLeadStatusDto {
+  @ApiProperty({ description: 'New lead status', enum: LeadStatus })
+  @IsNotEmpty()
+  @IsEnum(LeadStatus)
+  status: LeadStatus;
+
+  @ApiPropertyOptional({ description: 'Optional notes about the status change' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/src/leads/dto/create-lead-activity.dto.ts
+++ b/src/leads/dto/create-lead-activity.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { LeadActivityType } from '@prisma/client';
+
+export class CreateLeadActivityDto {
+  @ApiProperty({ description: 'Activity type', enum: LeadActivityType })
+  @IsNotEmpty()
+  @IsEnum(LeadActivityType)
+  type: LeadActivityType;
+
+  @ApiProperty({ description: 'Activity description', example: 'Called client to discuss property options' })
+  @IsNotEmpty()
+  @IsString()
+  description: string;
+}

--- a/src/leads/dto/create-lead.dto.ts
+++ b/src/leads/dto/create-lead.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsDate,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { LeadStatus, LeadPriority } from '@prisma/client';
+
+export class CreateLeadDto {
+  @ApiProperty({ description: 'Client UUID', example: '00000000-0000-0000-0000-000000000001' })
+  @IsNotEmpty()
+  @IsUUID()
+  clientId: string;
+
+  @ApiPropertyOptional({ description: 'Property UUID', example: '00000000-0000-0000-0000-000000000002' })
+  @IsOptional()
+  @IsUUID()
+  propertyId?: string;
+
+  @ApiPropertyOptional({ description: 'Lead status', enum: LeadStatus, default: LeadStatus.NEW })
+  @IsOptional()
+  @IsEnum(LeadStatus)
+  status?: LeadStatus = LeadStatus.NEW;
+
+  @ApiPropertyOptional({ description: 'Lead priority', enum: LeadPriority, default: LeadPriority.MEDIUM })
+  @IsOptional()
+  @IsEnum(LeadPriority)
+  priority?: LeadPriority = LeadPriority.MEDIUM;
+
+  @ApiPropertyOptional({ description: 'Lead source', example: 'Website' })
+  @IsOptional()
+  @IsString()
+  source?: string;
+
+  @ApiPropertyOptional({ description: 'Budget amount', example: 500000 })
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  budget?: number;
+
+  @ApiPropertyOptional({ description: 'Additional notes' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @ApiPropertyOptional({ description: 'Assigned agent UUID' })
+  @IsOptional()
+  @IsUUID()
+  assignedAgentId?: string;
+
+  @ApiPropertyOptional({ description: 'Next follow-up date', example: '2026-04-01T10:00:00Z' })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  nextFollowUp?: Date;
+}

--- a/src/leads/dto/lead-filter.dto.ts
+++ b/src/leads/dto/lead-filter.dto.ts
@@ -1,0 +1,44 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDate, IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { Type } from 'class-transformer';
+import { LeadStatus, LeadPriority } from '@prisma/client';
+import { PaginationDto } from '../../common/dto/pagination.dto.js';
+
+export class LeadFilterDto extends PaginationDto {
+  @ApiPropertyOptional({ description: 'Filter by lead status', enum: LeadStatus })
+  @IsOptional()
+  @IsEnum(LeadStatus)
+  status?: LeadStatus;
+
+  @ApiPropertyOptional({ description: 'Filter by priority', enum: LeadPriority })
+  @IsOptional()
+  @IsEnum(LeadPriority)
+  priority?: LeadPriority;
+
+  @ApiPropertyOptional({ description: 'Filter by assigned agent ID' })
+  @IsOptional()
+  @IsUUID()
+  assignedAgentId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter from date', example: '2026-01-01T00:00:00Z' })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  dateFrom?: Date;
+
+  @ApiPropertyOptional({ description: 'Filter to date', example: '2026-12-31T23:59:59Z' })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  dateTo?: Date;
+
+  @ApiPropertyOptional({ description: 'Sort field', enum: ['createdAt', 'priority', 'nextFollowUp'] })
+  @IsOptional()
+  @IsString()
+  sortBy?: 'createdAt' | 'priority' | 'nextFollowUp' = 'createdAt';
+
+  @ApiPropertyOptional({ description: 'Sort direction', enum: ['asc', 'desc'] })
+  @IsOptional()
+  @IsString()
+  sortOrder?: 'asc' | 'desc' = 'desc';
+}

--- a/src/leads/dto/update-lead.dto.ts
+++ b/src/leads/dto/update-lead.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateLeadDto } from './create-lead.dto.js';
+
+export class UpdateLeadDto extends PartialType(CreateLeadDto) {}

--- a/src/leads/leads.controller.ts
+++ b/src/leads/leads.controller.ts
@@ -1,0 +1,166 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { LeadsService } from './leads.service.js';
+import { CreateLeadDto } from './dto/create-lead.dto.js';
+import { UpdateLeadDto } from './dto/update-lead.dto.js';
+import { LeadFilterDto } from './dto/lead-filter.dto.js';
+import { ChangeLeadStatusDto } from './dto/change-lead-status.dto.js';
+import { AssignAgentDto } from './dto/assign-agent.dto.js';
+import { CreateLeadActivityDto } from './dto/create-lead-activity.dto.js';
+import { CurrentUser, type AuthenticatedUser } from '../common/decorators/current-user.decorator.js';
+import { Roles } from '../common/decorators/roles.decorator.js';
+import { AuthGuard } from '../common/guards/auth.guard.js';
+
+@ApiTags('Leads')
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Controller('api/leads')
+export class LeadsController {
+  constructor(private readonly leadsService: LeadsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new lead' })
+  @ApiResponse({ status: 201, description: 'Lead created successfully' })
+  create(
+    @Body() dto: CreateLeadDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.leadsService.create(dto, user.sub);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List leads with filters and pagination' })
+  findAll(
+    @Query() filter: LeadFilterDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    const isAdminOrManager = user.roles?.some((r) =>
+      ['admin', 'manager'].includes(r),
+    ) ?? false;
+    return this.leadsService.findAll(filter, user.sub, isAdminOrManager);
+  }
+
+  @Get('pipeline')
+  @ApiOperation({ summary: 'Get leads grouped by status for kanban pipeline view' })
+  getPipeline(@CurrentUser() user: AuthenticatedUser) {
+    const isAdminOrManager = user.roles?.some((r) =>
+      ['admin', 'manager'].includes(r),
+    ) ?? false;
+    return this.leadsService.getPipeline(user.sub, isAdminOrManager);
+  }
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Get lead statistics' })
+  getStats(@CurrentUser() user: AuthenticatedUser) {
+    const isAdminOrManager = user.roles?.some((r) =>
+      ['admin', 'manager'].includes(r),
+    ) ?? false;
+    return this.leadsService.getStats(user.sub, isAdminOrManager);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get lead by ID with client, property, and recent activities' })
+  @ApiParam({ name: 'id', description: 'Lead UUID' })
+  @ApiResponse({ status: 200, description: 'Lead details' })
+  @ApiResponse({ status: 404, description: 'Lead not found' })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.leadsService.findOne(id);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update a lead' })
+  @ApiParam({ name: 'id', description: 'Lead UUID' })
+  @ApiResponse({ status: 200, description: 'Lead updated' })
+  @ApiResponse({ status: 404, description: 'Lead not found' })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateLeadDto,
+  ) {
+    return this.leadsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Soft-delete a lead by marking it as LOST (admin only)' })
+  @ApiParam({ name: 'id', description: 'Lead UUID' })
+  @ApiResponse({ status: 200, description: 'Lead marked as LOST' })
+  @ApiResponse({ status: 404, description: 'Lead not found' })
+  remove(@Param('id', ParseUUIDPipe) id: string) {
+    return this.leadsService.remove(id);
+  }
+
+  @Patch(':id/status')
+  @ApiOperation({ summary: 'Change lead status (validates allowed transitions)' })
+  @ApiParam({ name: 'id', description: 'Lead UUID' })
+  @ApiResponse({ status: 200, description: 'Lead status changed' })
+  @ApiResponse({ status: 400, description: 'Invalid status transition' })
+  @ApiResponse({ status: 404, description: 'Lead not found' })
+  changeStatus(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: ChangeLeadStatusDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.leadsService.changeStatus(id, dto, user.sub);
+  }
+
+  @Patch(':id/assign')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Assign lead to an agent (admin/manager only)' })
+  @ApiParam({ name: 'id', description: 'Lead UUID' })
+  @ApiResponse({ status: 200, description: 'Agent assigned' })
+  @ApiResponse({ status: 404, description: 'Lead not found' })
+  assignAgent(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: AssignAgentDto,
+  ) {
+    return this.leadsService.assignAgent(id, dto.agentId);
+  }
+
+  @Post(':id/activities')
+  @ApiOperation({ summary: 'Add an activity to a lead' })
+  @ApiParam({ name: 'id', description: 'Lead UUID' })
+  @ApiResponse({ status: 201, description: 'Activity created' })
+  @ApiResponse({ status: 404, description: 'Lead not found' })
+  addActivity(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: CreateLeadActivityDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.leadsService.addActivity(id, dto, user.sub);
+  }
+
+  @Get(':id/activities')
+  @ApiOperation({ summary: 'Get paginated activities for a lead' })
+  @ApiParam({ name: 'id', description: 'Lead UUID' })
+  @ApiQuery({ name: 'page', required: false, description: 'Page number', example: 1 })
+  @ApiQuery({ name: 'limit', required: false, description: 'Items per page', example: 20 })
+  @ApiResponse({ status: 200, description: 'Paginated lead activities' })
+  @ApiResponse({ status: 404, description: 'Lead not found' })
+  getActivities(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('page', new ParseIntPipe({ optional: true })) page = 1,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit = 20,
+  ) {
+    return this.leadsService.getActivities(id, page, limit);
+  }
+}

--- a/src/leads/leads.module.ts
+++ b/src/leads/leads.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { LeadsController } from './leads.controller.js';
+import { LeadsService } from './leads.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [LeadsController],
+  providers: [LeadsService],
+  exports: [LeadsService],
+})
+export class LeadsModule {}

--- a/src/leads/leads.service.ts
+++ b/src/leads/leads.service.ts
@@ -1,0 +1,327 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma, LeadStatus, LeadActivityType } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CreateLeadDto } from './dto/create-lead.dto.js';
+import { UpdateLeadDto } from './dto/update-lead.dto.js';
+import { LeadFilterDto } from './dto/lead-filter.dto.js';
+import { ChangeLeadStatusDto } from './dto/change-lead-status.dto.js';
+import { CreateLeadActivityDto } from './dto/create-lead-activity.dto.js';
+import { paginate, type PaginatedResult } from '../common/dto/pagination.dto.js';
+
+const STATUS_TRANSITIONS: Record<LeadStatus, LeadStatus[]> = {
+  [LeadStatus.NEW]: [LeadStatus.CONTACTED, LeadStatus.LOST],
+  [LeadStatus.CONTACTED]: [LeadStatus.QUALIFIED, LeadStatus.LOST],
+  [LeadStatus.QUALIFIED]: [LeadStatus.PROPOSAL, LeadStatus.LOST],
+  [LeadStatus.PROPOSAL]: [LeadStatus.NEGOTIATION, LeadStatus.LOST],
+  [LeadStatus.NEGOTIATION]: [LeadStatus.WON, LeadStatus.LOST],
+  [LeadStatus.WON]: [],
+  [LeadStatus.LOST]: [LeadStatus.NEW],
+};
+
+@Injectable()
+export class LeadsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateLeadDto, performedBy: string) {
+    const lead = await this.prisma.lead.create({
+      data: {
+        ...dto,
+        status: dto.status ?? LeadStatus.NEW,
+      },
+    });
+
+    await this.prisma.leadActivity.create({
+      data: {
+        leadId: lead.id,
+        type: LeadActivityType.STATUS_CHANGE,
+        description: `Lead created with status ${lead.status}`,
+        performedBy,
+      },
+    });
+
+    return lead;
+  }
+
+  async findAll(
+    filter: LeadFilterDto,
+    agentId?: string,
+    isAdminOrManager = false,
+  ): Promise<PaginatedResult<any>> {
+    const where = this.buildWhereClause(filter, agentId, isAdminOrManager);
+
+    const [data, total] = await Promise.all([
+      this.prisma.lead.findMany({
+        where,
+        skip: filter.skip,
+        take: filter.limit,
+        orderBy: { [filter.sortBy ?? 'createdAt']: filter.sortOrder ?? 'desc' },
+        include: {
+          client: {
+            select: { id: true, firstName: true, lastName: true, phone: true },
+          },
+          property: {
+            select: { id: true, title: true, address: true },
+          },
+        },
+      }),
+      this.prisma.lead.count({ where }),
+    ]);
+
+    return paginate(data, total, filter);
+  }
+
+  async findOne(id: string) {
+    const lead = await this.prisma.lead.findUnique({
+      where: { id },
+      include: {
+        client: true,
+        property: true,
+        activities: {
+          orderBy: { createdAt: 'desc' },
+          take: 20,
+        },
+        _count: { select: { activities: true } },
+      },
+    });
+
+    if (!lead) {
+      throw new NotFoundException(`Lead with ID "${id}" not found`);
+    }
+
+    return lead;
+  }
+
+  async update(id: string, dto: UpdateLeadDto) {
+    await this.ensureExists(id);
+
+    return this.prisma.lead.update({
+      where: { id },
+      data: dto,
+    });
+  }
+
+  async remove(id: string) {
+    await this.ensureExists(id);
+
+    return this.prisma.lead.update({
+      where: { id },
+      data: { status: LeadStatus.LOST },
+    });
+  }
+
+  async changeStatus(id: string, dto: ChangeLeadStatusDto, performedBy: string) {
+    const lead = await this.prisma.lead.findUnique({
+      where: { id },
+      select: { id: true, status: true },
+    });
+
+    if (!lead) {
+      throw new NotFoundException(`Lead with ID "${id}" not found`);
+    }
+
+    const allowed = STATUS_TRANSITIONS[lead.status] ?? [];
+    if (!allowed.includes(dto.status)) {
+      throw new BadRequestException(
+        `Cannot transition lead from ${lead.status} to ${dto.status}. Allowed transitions: ${allowed.join(', ') || 'none'}`,
+      );
+    }
+
+    const [updated] = await this.prisma.$transaction([
+      this.prisma.lead.update({
+        where: { id },
+        data: { status: dto.status },
+      }),
+      this.prisma.leadActivity.create({
+        data: {
+          leadId: id,
+          type: LeadActivityType.STATUS_CHANGE,
+          description: dto.notes
+            ? `Status changed from ${lead.status} to ${dto.status}: ${dto.notes}`
+            : `Status changed from ${lead.status} to ${dto.status}`,
+          performedBy,
+        },
+      }),
+    ]);
+
+    return updated;
+  }
+
+  async assignAgent(id: string, agentId: string) {
+    await this.ensureExists(id);
+
+    return this.prisma.lead.update({
+      where: { id },
+      data: { assignedAgentId: agentId },
+    });
+  }
+
+  async addActivity(leadId: string, dto: CreateLeadActivityDto, performedBy: string) {
+    await this.ensureExists(leadId);
+
+    return this.prisma.leadActivity.create({
+      data: {
+        leadId,
+        type: dto.type,
+        description: dto.description,
+        performedBy,
+      },
+    });
+  }
+
+  async getActivities(leadId: string, page = 1, limit = 20): Promise<PaginatedResult<any>> {
+    await this.ensureExists(leadId);
+
+    const skip = (page - 1) * limit;
+
+    const [data, total] = await Promise.all([
+      this.prisma.leadActivity.findMany({
+        where: { leadId },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.leadActivity.count({ where: { leadId } }),
+    ]);
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async getPipeline(agentId?: string, isAdminOrManager = false) {
+    const where: Prisma.LeadWhereInput =
+      !isAdminOrManager && agentId ? { assignedAgentId: agentId } : {};
+
+    const leads = await this.prisma.lead.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        status: true,
+        priority: true,
+        source: true,
+        budget: true,
+        nextFollowUp: true,
+        createdAt: true,
+        client: {
+          select: { id: true, firstName: true, lastName: true },
+        },
+        property: {
+          select: { id: true, title: true },
+        },
+      },
+    });
+
+    const pipeline: Record<LeadStatus, typeof leads> = {
+      [LeadStatus.NEW]: [],
+      [LeadStatus.CONTACTED]: [],
+      [LeadStatus.QUALIFIED]: [],
+      [LeadStatus.PROPOSAL]: [],
+      [LeadStatus.NEGOTIATION]: [],
+      [LeadStatus.WON]: [],
+      [LeadStatus.LOST]: [],
+    };
+
+    for (const lead of leads) {
+      pipeline[lead.status].push(lead);
+    }
+
+    return pipeline;
+  }
+
+  async getStats(agentId?: string, isAdminOrManager = false) {
+    const where: Prisma.LeadWhereInput =
+      !isAdminOrManager && agentId ? { assignedAgentId: agentId } : {};
+
+    const [total, byStatus, byPriority, bySource] = await Promise.all([
+      this.prisma.lead.count({ where }),
+      this.prisma.lead.groupBy({
+        by: ['status'],
+        where,
+        _count: true,
+      }),
+      this.prisma.lead.groupBy({
+        by: ['priority'],
+        where,
+        _count: true,
+      }),
+      this.prisma.lead.groupBy({
+        by: ['source'],
+        where,
+        _count: true,
+      }),
+    ]);
+
+    return {
+      total,
+      byStatus: byStatus.map((g) => ({ status: g.status, count: g._count })),
+      byPriority: byPriority.map((g) => ({ priority: g.priority, count: g._count })),
+      bySource: bySource.map((g) => ({ source: g.source, count: g._count })),
+    };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.lead.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    if (!exists) {
+      throw new NotFoundException(`Lead with ID "${id}" not found`);
+    }
+  }
+
+  private buildWhereClause(
+    filter: LeadFilterDto,
+    agentId?: string,
+    isAdminOrManager = false,
+  ): Prisma.LeadWhereInput {
+    const where: Prisma.LeadWhereInput = {};
+
+    if (filter.status) where.status = filter.status;
+    if (filter.priority) where.priority = filter.priority;
+    if (filter.assignedAgentId) where.assignedAgentId = filter.assignedAgentId;
+
+    if (filter.dateFrom || filter.dateTo) {
+      where.createdAt = {
+        ...(filter.dateFrom ? { gte: filter.dateFrom } : {}),
+        ...(filter.dateTo ? { lte: filter.dateTo } : {}),
+      };
+    }
+
+    // Agent scoping: agents only see their own leads unless admin/manager
+    if (!isAdminOrManager && agentId) {
+      where.assignedAgentId = agentId;
+    }
+
+    if (filter.search) {
+      where.OR = [
+        {
+          client: {
+            firstName: { contains: filter.search, mode: 'insensitive' },
+          },
+        },
+        {
+          client: {
+            lastName: { contains: filter.search, mode: 'insensitive' },
+          },
+        },
+        {
+          client: {
+            phone: { contains: filter.search },
+          },
+        },
+        { notes: { contains: filter.search, mode: 'insensitive' } },
+      ];
+    }
+
+    return where;
+  }
+}


### PR DESCRIPTION
## Summary

- Implements the full `src/leads/` module following the same patterns as `src/clients/`
- 6 DTOs: `CreateLeadDto`, `UpdateLeadDto`, `LeadFilterDto`, `ChangeLeadStatusDto`, `AssignAgentDto`, `CreateLeadActivityDto`
- `LeadsService` with CRUD, status transitions, pipeline (kanban), stats, and activity tracking
- `LeadsController` with 11 endpoints under `api/leads`
- `LeadsModule` registered in `AppModule`

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/leads` | Create a new lead (auto-creates STATUS_CHANGE activity) |
| GET | `/api/leads` | List leads with filters, pagination, agent scoping |
| GET | `/api/leads/pipeline` | Leads grouped by status for kanban view |
| GET | `/api/leads/stats` | Counts by status, priority, source |
| GET | `/api/leads/:id` | Lead detail with client, property, last 20 activities |
| PUT | `/api/leads/:id` | Update lead fields |
| DELETE | `/api/leads/:id` | Soft-delete (set status to LOST) — admin only |
| PATCH | `/api/leads/:id/status` | Change status with validated transitions |
| PATCH | `/api/leads/:id/assign` | Assign agent — admin/manager only |
| POST | `/api/leads/:id/activities` | Add activity to a lead |
| GET | `/api/leads/:id/activities` | Paginated activity list for a lead |

## Status Transitions

`NEW → CONTACTED → QUALIFIED → PROPOSAL → NEGOTIATION → WON`  
Any state (except WON) can transition to `LOST`. `LOST` can reopen to `NEW`.

## Test plan

- [ ] POST `/api/leads` creates a lead and a STATUS_CHANGE activity
- [ ] GET `/api/leads` returns paginated results; agents see only their own leads
- [ ] GET `/api/leads/pipeline` returns leads bucketed by status
- [ ] GET `/api/leads/stats` returns total, byStatus, byPriority, bySource
- [ ] PATCH `/api/leads/:id/status` rejects invalid transitions with 400
- [ ] DELETE `/api/leads/:id` soft-deletes by setting status to LOST (admin only)
- [ ] GET/POST `/api/leads/:id/activities` work correctly with pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)