### PR TITLE
feat(pdf): PDF Generation — Contracts, Invoices & Reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@nestjs/config": "^4.0.3",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.1.1",
+        "@nestjs/serve-static": "^5.0.4",
         "@nestjs/swagger": "^11.2.6",
         "@nestjs/terminus": "^11.0.0",
         "@nestjs/throttler": "^6.5.0",
@@ -23,6 +25,7 @@
         "cookie-parser": "^1.4.7",
         "dotenv": "^17.3.1",
         "helmet": "^8.1.0",
+        "pdfkit": "^0.18.0",
         "prisma": "^7.4.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
@@ -37,6 +40,7 @@
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
+        "@types/pdfkit": "^0.17.5",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -2537,6 +2541,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.1.tgz",
+      "integrity": "sha512-kQl1RRgi02GJ0uaUGCrXHCcwISsCsJDciCKe38ykJZgnAeeoeVWs8luWtBo4AqAAXm4nS5K8RlV0smHUJ4+2FA==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.9",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
@@ -2633,6 +2650,33 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/serve-static": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-5.0.4.tgz",
+      "integrity": "sha512-3kO1M9D3vsPyWPFardxIjUYeuolS58PnhCoBTkS7t3BrdZFZCKHnBZ15js+UOzOR2Q6HmD7ssGjLd0DVYVdvOw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-to-regexp": "8.3.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.4",
+        "@nestjs/common": "^11.0.2",
+        "@nestjs/core": "^11.0.2",
+        "express": "^5.0.1",
+        "fastify": "^5.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "fastify": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/swagger": {
@@ -2777,11 +2821,22 @@
         "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -3058,6 +3113,15 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -3309,6 +3373,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -3323,6 +3393,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pdfkit": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.17.5.tgz",
+      "integrity": "sha512-T3ZHnvF91HsEco5ClhBCOuBwobZfPcI2jaiSHybkkKYq4KhVIIurod94JVKvDIG0JXT6o3KiERC0X0//m8dyrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -4577,7 +4657,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4704,6 +4783,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -5419,6 +5507,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5581,6 +5686,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "4.0.4",
@@ -6228,7 +6339,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -6405,6 +6515,32 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -8078,6 +8214,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8220,6 +8362,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -8342,6 +8503,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -8958,6 +9128,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9080,6 +9256,20 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pdfkit": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
+      "integrity": "sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -9409,6 +9599,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/postgres": {
       "version": "3.4.7",
@@ -9836,6 +10031,12 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.12.0",
@@ -10674,6 +10875,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -11087,6 +11294,26 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cookie-parser": "^1.4.7",
     "dotenv": "^17.3.1",
     "helmet": "^8.1.0",
+    "pdfkit": "^0.18.0",
     "prisma": "^7.4.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
@@ -56,6 +57,7 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
+    "@types/pdfkit": "^0.17.5",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { PropertiesModule } from './properties/properties.module.js';
 import { ContractsModule } from './contracts/contracts.module.js';
 import { InvoicesModule } from './invoices/invoices.module.js';
 import { LeadsModule } from './leads/leads.module.js';
+import { PdfModule } from './pdf/pdf.module.js';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { LeadsModule } from './leads/leads.module.js';
     ContractsModule,
     InvoicesModule,
     LeadsModule,
+    PdfModule,
   ],
   providers: [
     {

--- a/src/pdf/dto/generate-report.dto.ts
+++ b/src/pdf/dto/generate-report.dto.ts
@@ -1,0 +1,23 @@
+import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export enum ReportType {
+  MONTHLY_REVENUE = 'monthly_revenue',
+  AGENT_PERFORMANCE = 'agent_performance',
+}
+
+export class GenerateReportDto {
+  @ApiProperty({ enum: ReportType, description: 'Type of report to generate' })
+  @IsEnum(ReportType)
+  type: ReportType;
+
+  @ApiPropertyOptional({ description: 'Month in YYYY-MM format (defaults to current month)' })
+  @IsOptional()
+  @IsString()
+  month?: string;
+
+  @ApiPropertyOptional({ description: 'Agent ID (required for agent_performance report)' })
+  @IsOptional()
+  @IsUUID()
+  agentId?: string;
+}

--- a/src/pdf/pdf-base.template.ts
+++ b/src/pdf/pdf-base.template.ts
@@ -1,0 +1,226 @@
+import PDFDocument from 'pdfkit';
+
+export interface CompanyInfo {
+  name: string;
+  nameAr?: string;
+  address?: string;
+  phone?: string;
+  email?: string;
+  logoPath?: string;
+}
+
+const DEFAULT_COMPANY: CompanyInfo = {
+  name: 'Real Estate CRM',
+  nameAr: 'إدارة العقارات',
+  address: 'Cairo, Egypt',
+  phone: '+20 2 xxxx xxxx',
+  email: 'info@realestate-crm.com',
+};
+
+export abstract class PdfBaseTemplate {
+  protected primaryColor = '#1a365d';
+  protected accentColor = '#2b6cb0';
+  protected lightGray = '#f7fafc';
+  protected borderColor = '#e2e8f0';
+  protected textColor = '#2d3748';
+
+  protected createDocument(): typeof PDFDocument.prototype {
+    return new PDFDocument({
+      size: 'A4',
+      margins: { top: 50, bottom: 50, left: 50, right: 50 },
+      bufferPages: true,
+    });
+  }
+
+  protected addHeader(
+    doc: typeof PDFDocument.prototype,
+    title: string,
+    company: CompanyInfo = DEFAULT_COMPANY,
+  ): void {
+    const pageWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+
+    // Company name
+    doc
+      .fontSize(18)
+      .fillColor(this.primaryColor)
+      .text(company.name, { align: 'center' });
+
+    if (company.nameAr) {
+      doc
+        .fontSize(14)
+        .fillColor(this.accentColor)
+        .text(company.nameAr, { align: 'center' });
+    }
+
+    doc.moveDown(0.3);
+
+    // Contact info
+    if (company.address || company.phone || company.email) {
+      const parts: string[] = [];
+      if (company.address) parts.push(company.address);
+      if (company.phone) parts.push(company.phone);
+      if (company.email) parts.push(company.email);
+      doc
+        .fontSize(8)
+        .fillColor('#718096')
+        .text(parts.join('  |  '), { align: 'center' });
+    }
+
+    doc.moveDown(0.5);
+
+    // Divider line
+    const y = doc.y;
+    doc
+      .strokeColor(this.primaryColor)
+      .lineWidth(2)
+      .moveTo(doc.page.margins.left, y)
+      .lineTo(doc.page.margins.left + pageWidth, y)
+      .stroke();
+
+    doc.moveDown(0.5);
+
+    // Document title
+    doc
+      .fontSize(16)
+      .fillColor(this.primaryColor)
+      .text(title, { align: 'center' });
+
+    doc.moveDown(1);
+  }
+
+  protected addFooter(doc: typeof PDFDocument.prototype): void {
+    const pages = doc.bufferedPageRange();
+    for (let i = 0; i < pages.count; i++) {
+      doc.switchToPage(i);
+      const pageWidth = doc.page.width;
+      doc
+        .fontSize(8)
+        .fillColor('#a0aec0')
+        .text(
+          `Page ${i + 1} of ${pages.count}`,
+          doc.page.margins.left,
+          doc.page.height - 35,
+          { align: 'center', width: pageWidth - doc.page.margins.left - doc.page.margins.right },
+        );
+      doc.text(
+        `Generated on ${new Date().toLocaleDateString('en-GB')}`,
+        doc.page.margins.left,
+        doc.page.height - 25,
+        { align: 'center', width: pageWidth - doc.page.margins.left - doc.page.margins.right },
+      );
+    }
+  }
+
+  protected addSection(
+    doc: typeof PDFDocument.prototype,
+    title: string,
+  ): void {
+    doc
+      .fontSize(12)
+      .fillColor(this.primaryColor)
+      .text(title, { underline: true });
+    doc.moveDown(0.5);
+  }
+
+  protected addLabelValue(
+    doc: typeof PDFDocument.prototype,
+    label: string,
+    value: string,
+  ): void {
+    doc
+      .fontSize(10)
+      .fillColor('#718096')
+      .text(label, { continued: true })
+      .fillColor(this.textColor)
+      .text(`  ${value}`);
+  }
+
+  protected addTable(
+    doc: typeof PDFDocument.prototype,
+    headers: string[],
+    rows: string[][],
+    colWidths?: number[],
+  ): void {
+    const pageWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+    const cols = headers.length;
+    const widths = colWidths ?? headers.map(() => pageWidth / cols);
+    const rowHeight = 25;
+    const startX = doc.page.margins.left;
+    let y = doc.y;
+
+    // Header row
+    doc
+      .rect(startX, y, pageWidth, rowHeight)
+      .fill(this.primaryColor);
+
+    let x = startX;
+    headers.forEach((h, i) => {
+      doc
+        .fontSize(9)
+        .fillColor('#ffffff')
+        .text(h, x + 5, y + 7, { width: widths[i] - 10, align: 'left' });
+      x += widths[i];
+    });
+
+    y += rowHeight;
+
+    // Data rows
+    rows.forEach((row, rowIdx) => {
+      // Check for page break
+      if (y + rowHeight > doc.page.height - doc.page.margins.bottom - 40) {
+        doc.addPage();
+        y = doc.page.margins.top;
+      }
+
+      const bgColor = rowIdx % 2 === 0 ? this.lightGray : '#ffffff';
+      doc
+        .rect(startX, y, pageWidth, rowHeight)
+        .fill(bgColor);
+
+      x = startX;
+      row.forEach((cell, i) => {
+        doc
+          .fontSize(9)
+          .fillColor(this.textColor)
+          .text(cell, x + 5, y + 7, { width: widths[i] - 10, align: 'left' });
+        x += widths[i];
+      });
+
+      y += rowHeight;
+    });
+
+    // Bottom border
+    doc
+      .strokeColor(this.borderColor)
+      .lineWidth(1)
+      .moveTo(startX, y)
+      .lineTo(startX + pageWidth, y)
+      .stroke();
+
+    doc.y = y + 10;
+  }
+
+  protected formatCurrency(amount: number | string): string {
+    const num = typeof amount === 'string' ? parseFloat(amount) : amount;
+    return `EGP ${num.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  }
+
+  protected formatDate(date: Date | string): string {
+    const d = typeof date === 'string' ? new Date(date) : date;
+    return d.toLocaleDateString('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    });
+  }
+
+  protected streamToBuffer(doc: typeof PDFDocument.prototype): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+      doc.on('error', reject);
+      doc.end();
+    });
+  }
+}

--- a/src/pdf/pdf.controller.spec.ts
+++ b/src/pdf/pdf.controller.spec.ts
@@ -1,0 +1,110 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PdfController } from './pdf.controller';
+import { PdfService } from './pdf.service';
+import { ReportType } from './dto/generate-report.dto';
+
+const mockPdfBuffer = Buffer.from('%PDF-1.4 mock');
+
+const mockService = {
+  generateContractPdf: jest.fn().mockResolvedValue(mockPdfBuffer),
+  generateInvoicePdf: jest.fn().mockResolvedValue(mockPdfBuffer),
+  generatePropertyPdf: jest.fn().mockResolvedValue(mockPdfBuffer),
+  generateReport: jest.fn().mockResolvedValue(mockPdfBuffer),
+};
+
+const mockResponse = () => {
+  const res: any = {};
+  res.set = jest.fn().mockReturnValue(res);
+  res.end = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('PdfController', () => {
+  let controller: PdfController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PdfController],
+      providers: [{ provide: PdfService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get<PdfController>(PdfController);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('contractPdf', () => {
+    it('should return PDF buffer with correct headers', async () => {
+      const res = mockResponse();
+      await controller.contractPdf('uuid-1', res);
+
+      expect(mockService.generateContractPdf).toHaveBeenCalledWith('uuid-1');
+      expect(res.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'Content-Type': 'application/pdf',
+        }),
+      );
+      expect(res.end).toHaveBeenCalledWith(mockPdfBuffer);
+    });
+  });
+
+  describe('invoicePdf', () => {
+    it('should return PDF buffer with correct headers', async () => {
+      const res = mockResponse();
+      await controller.invoicePdf('uuid-2', res);
+
+      expect(mockService.generateInvoicePdf).toHaveBeenCalledWith('uuid-2');
+      expect(res.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'Content-Type': 'application/pdf',
+        }),
+      );
+      expect(res.end).toHaveBeenCalledWith(mockPdfBuffer);
+    });
+  });
+
+  describe('propertyPdf', () => {
+    it('should return PDF buffer with correct headers', async () => {
+      const res = mockResponse();
+      await controller.propertyPdf('uuid-3', res);
+
+      expect(mockService.generatePropertyPdf).toHaveBeenCalledWith('uuid-3');
+      expect(res.end).toHaveBeenCalledWith(mockPdfBuffer);
+    });
+  });
+
+  describe('generateReport', () => {
+    it('should generate monthly revenue report', async () => {
+      const res = mockResponse();
+      const dto = { type: ReportType.MONTHLY_REVENUE, month: '2026-03' };
+      await controller.generateReport(dto, res);
+
+      expect(mockService.generateReport).toHaveBeenCalledWith(
+        ReportType.MONTHLY_REVENUE,
+        '2026-03',
+        undefined,
+      );
+      expect(res.end).toHaveBeenCalledWith(mockPdfBuffer);
+    });
+
+    it('should generate agent performance report', async () => {
+      const res = mockResponse();
+      const dto = {
+        type: ReportType.AGENT_PERFORMANCE,
+        month: '2026-03',
+        agentId: 'agent-1',
+      };
+      await controller.generateReport(dto, res);
+
+      expect(mockService.generateReport).toHaveBeenCalledWith(
+        ReportType.AGENT_PERFORMANCE,
+        '2026-03',
+        'agent-1',
+      );
+      expect(res.end).toHaveBeenCalledWith(mockPdfBuffer);
+    });
+  });
+});

--- a/src/pdf/pdf.controller.ts
+++ b/src/pdf/pdf.controller.ts
@@ -1,0 +1,112 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Res,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiProduces,
+} from '@nestjs/swagger';
+import type { Response } from 'express';
+import { PdfService } from './pdf.service.js';
+import { GenerateReportDto } from './dto/generate-report.dto.js';
+import { Roles } from '../common/decorators/roles.decorator.js';
+import { AuthGuard } from '../common/guards/auth.guard.js';
+
+@ApiTags('PDF Generation')
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Controller('api')
+export class PdfController {
+  constructor(private readonly pdfService: PdfService) {}
+
+  @Get('contracts/:id/pdf')
+  @ApiOperation({ summary: 'Download contract as PDF' })
+  @ApiParam({ name: 'id', description: 'Contract UUID' })
+  @ApiProduces('application/pdf')
+  @ApiResponse({ status: 200, description: 'PDF file' })
+  @ApiResponse({ status: 404, description: 'Contract not found' })
+  async contractPdf(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Res() res: Response,
+  ) {
+    const buffer = await this.pdfService.generateContractPdf(id);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="contract-${id}.pdf"`,
+      'Content-Length': buffer.length,
+    });
+    res.end(buffer);
+  }
+
+  @Get('invoices/:id/pdf')
+  @ApiOperation({ summary: 'Download invoice as PDF' })
+  @ApiParam({ name: 'id', description: 'Invoice UUID' })
+  @ApiProduces('application/pdf')
+  @ApiResponse({ status: 200, description: 'PDF file' })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  async invoicePdf(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Res() res: Response,
+  ) {
+    const buffer = await this.pdfService.generateInvoicePdf(id);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="invoice-${id}.pdf"`,
+      'Content-Length': buffer.length,
+    });
+    res.end(buffer);
+  }
+
+  @Get('properties/:id/pdf')
+  @ApiOperation({ summary: 'Download property listing as PDF' })
+  @ApiParam({ name: 'id', description: 'Property UUID' })
+  @ApiProduces('application/pdf')
+  @ApiResponse({ status: 200, description: 'PDF file' })
+  @ApiResponse({ status: 404, description: 'Property not found' })
+  async propertyPdf(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Res() res: Response,
+  ) {
+    const buffer = await this.pdfService.generatePropertyPdf(id);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="property-${id}.pdf"`,
+      'Content-Length': buffer.length,
+    });
+    res.end(buffer);
+  }
+
+  @Post('reports/generate-pdf')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Generate a report PDF (monthly revenue or agent performance)' })
+  @ApiProduces('application/pdf')
+  @ApiResponse({ status: 200, description: 'PDF file' })
+  @ApiResponse({ status: 400, description: 'Invalid report parameters' })
+  async generateReport(
+    @Body() dto: GenerateReportDto,
+    @Res() res: Response,
+  ) {
+    const buffer = await this.pdfService.generateReport(
+      dto.type,
+      dto.month,
+      dto.agentId,
+    );
+    const filename = `report-${dto.type}-${dto.month ?? 'current'}.pdf`;
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Content-Length': buffer.length,
+    });
+    res.end(buffer);
+  }
+}

--- a/src/pdf/pdf.module.ts
+++ b/src/pdf/pdf.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module.js';
+import { PdfService } from './pdf.service.js';
+import { PdfController } from './pdf.controller.js';
+import { ContractPdfTemplate } from './templates/contract.template.js';
+import { InvoicePdfTemplate } from './templates/invoice.template.js';
+import { ReportPdfTemplate } from './templates/report.template.js';
+import { PropertyPdfTemplate } from './templates/property.template.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [PdfController],
+  providers: [
+    PdfService,
+    ContractPdfTemplate,
+    InvoicePdfTemplate,
+    ReportPdfTemplate,
+    PropertyPdfTemplate,
+  ],
+  exports: [PdfService],
+})
+export class PdfModule {}

--- a/src/pdf/pdf.service.ts
+++ b/src/pdf/pdf.service.ts
@@ -1,0 +1,195 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { ContractPdfTemplate } from './templates/contract.template.js';
+import { InvoicePdfTemplate } from './templates/invoice.template.js';
+import { ReportPdfTemplate } from './templates/report.template.js';
+import type { MonthlyRevenueData, AgentPerformanceData } from './templates/report.template.js';
+import { PropertyPdfTemplate } from './templates/property.template.js';
+import { ReportType } from './dto/generate-report.dto.js';
+
+@Injectable()
+export class PdfService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly contractTemplate: ContractPdfTemplate,
+    private readonly invoiceTemplate: InvoicePdfTemplate,
+    private readonly reportTemplate: ReportPdfTemplate,
+    private readonly propertyTemplate: PropertyPdfTemplate,
+  ) {}
+
+  async generateContractPdf(contractId: string): Promise<Buffer> {
+    const contract = await this.prisma.contract.findUnique({
+      where: { id: contractId },
+      include: { property: true, client: true },
+    });
+
+    if (!contract) {
+      throw new NotFoundException(`Contract ${contractId} not found`);
+    }
+
+    return this.contractTemplate.generate(contract);
+  }
+
+  async generateInvoicePdf(invoiceId: string): Promise<Buffer> {
+    const invoice = await this.prisma.invoice.findUnique({
+      where: { id: invoiceId },
+      include: {
+        contract: {
+          include: { property: true, client: true },
+        },
+      },
+    });
+
+    if (!invoice) {
+      throw new NotFoundException(`Invoice ${invoiceId} not found`);
+    }
+
+    return this.invoiceTemplate.generate(invoice);
+  }
+
+  async generatePropertyPdf(propertyId: string): Promise<Buffer> {
+    const property = await this.prisma.property.findUnique({
+      where: { id: propertyId },
+      include: { images: { orderBy: { order: 'asc' } } },
+    });
+
+    if (!property) {
+      throw new NotFoundException(`Property ${propertyId} not found`);
+    }
+
+    return this.propertyTemplate.generate(property);
+  }
+
+  async generateReport(
+    type: ReportType,
+    month?: string,
+    agentId?: string,
+  ): Promise<Buffer> {
+    // Default to current month
+    const now = new Date();
+    const periodStr = month ?? `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const [year, mon] = periodStr.split('-').map(Number);
+    const startDate = new Date(year, mon - 1, 1);
+    const endDate = new Date(year, mon, 1);
+
+    switch (type) {
+      case ReportType.MONTHLY_REVENUE:
+        return this.generateMonthlyRevenueReport(periodStr, startDate, endDate);
+      case ReportType.AGENT_PERFORMANCE:
+        if (!agentId) {
+          throw new BadRequestException('agentId is required for agent_performance report');
+        }
+        return this.generateAgentPerformanceReport(agentId, periodStr, startDate, endDate);
+      default:
+        throw new BadRequestException(`Unknown report type: ${type}`);
+    }
+  }
+
+  private async generateMonthlyRevenueReport(
+    period: string,
+    startDate: Date,
+    endDate: Date,
+  ): Promise<Buffer> {
+    // Invoices created in the period
+    const invoices = await this.prisma.invoice.findMany({
+      where: {
+        createdAt: { gte: startDate, lt: endDate },
+      },
+      include: {
+        contract: { include: { property: true } },
+      },
+    });
+
+    const totalInvoiced = invoices.reduce((sum, i) => sum + Number(i.amount), 0);
+    const totalCollected = invoices
+      .filter((i) => i.status === 'PAID')
+      .reduce((sum, i) => sum + Number(i.amount), 0);
+    const totalOverdue = invoices
+      .filter((i) => i.status === 'OVERDUE')
+      .reduce((sum, i) => sum + Number(i.amount), 0);
+
+    // Group by status
+    const statusMap = new Map<string, { count: number; amount: number }>();
+    for (const inv of invoices) {
+      const entry = statusMap.get(inv.status) ?? { count: 0, amount: 0 };
+      entry.count++;
+      entry.amount += Number(inv.amount);
+      statusMap.set(inv.status, entry);
+    }
+
+    // Top properties
+    const propertyRevMap = new Map<string, { title: string; revenue: number }>();
+    for (const inv of invoices.filter((i) => i.status === 'PAID')) {
+      const key = inv.contract.propertyId;
+      const entry = propertyRevMap.get(key) ?? {
+        title: inv.contract.property.title,
+        revenue: 0,
+      };
+      entry.revenue += Number(inv.amount);
+      propertyRevMap.set(key, entry);
+    }
+
+    const data: MonthlyRevenueData = {
+      period,
+      totalInvoiced,
+      totalCollected,
+      totalOverdue,
+      invoicesByStatus: Array.from(statusMap.entries()).map(([status, v]) => ({
+        status,
+        ...v,
+      })),
+      topProperties: Array.from(propertyRevMap.values())
+        .sort((a, b) => b.revenue - a.revenue)
+        .slice(0, 10),
+    };
+
+    return this.reportTemplate.generateMonthlyRevenue(data);
+  }
+
+  private async generateAgentPerformanceReport(
+    agentId: string,
+    period: string,
+    startDate: Date,
+    endDate: Date,
+  ): Promise<Buffer> {
+    const [leads, contracts, activities] = await Promise.all([
+      this.prisma.lead.findMany({
+        where: {
+          assignedAgentId: agentId,
+          createdAt: { gte: startDate, lt: endDate },
+        },
+      }),
+      this.prisma.contract.findMany({
+        where: {
+          agentId,
+          createdAt: { gte: startDate, lt: endDate },
+        },
+      }),
+      this.prisma.leadActivity.findMany({
+        where: {
+          performedBy: agentId,
+          createdAt: { gte: startDate, lt: endDate },
+        },
+      }),
+    ]);
+
+    const leadsWon = leads.filter((l) => l.status === 'WON').length;
+    const leadsLost = leads.filter((l) => l.status === 'LOST').length;
+    const totalRevenue = contracts.reduce((sum, c) => sum + Number(c.totalAmount), 0);
+
+    const data: AgentPerformanceData = {
+      agentId,
+      agentName: agentId, // Would be replaced with actual agent name from IAM
+      period,
+      leadsAssigned: leads.length,
+      leadsWon,
+      leadsLost,
+      conversionRate: leads.length > 0 ? (leadsWon / leads.length) * 100 : 0,
+      contractsClosed: contracts.filter((c) => c.status === 'COMPLETED').length,
+      totalRevenue,
+      activitiesLogged: activities.length,
+    };
+
+    return this.reportTemplate.generateAgentPerformance(data);
+  }
+}

--- a/src/pdf/templates/contract.template.ts
+++ b/src/pdf/templates/contract.template.ts
@@ -1,0 +1,121 @@
+import { Injectable } from '@nestjs/common';
+import { PdfBaseTemplate } from '../pdf-base.template.js';
+import type { Contract, Property, Client } from '@prisma/client';
+
+type ContractWithRelations = Contract & {
+  property: Property;
+  client: Client;
+};
+
+@Injectable()
+export class ContractPdfTemplate extends PdfBaseTemplate {
+  async generate(contract: ContractWithRelations): Promise<Buffer> {
+    const doc = this.createDocument();
+
+    this.addHeader(doc, 'CONTRACT / عقد');
+
+    // Contract info
+    this.addSection(doc, 'Contract Details');
+    this.addLabelValue(doc, 'Contract ID:', contract.id);
+    this.addLabelValue(doc, 'Type:', contract.type);
+    this.addLabelValue(doc, 'Status:', contract.status);
+    this.addLabelValue(doc, 'Start Date:', this.formatDate(contract.startDate));
+    if (contract.endDate) {
+      this.addLabelValue(doc, 'End Date:', this.formatDate(contract.endDate));
+    }
+    this.addLabelValue(doc, 'Total Amount:', this.formatCurrency(contract.totalAmount.toString()));
+    doc.moveDown(1);
+
+    // Property info
+    this.addSection(doc, 'Property Details');
+    this.addLabelValue(doc, 'Title:', contract.property.title);
+    this.addLabelValue(doc, 'Type:', contract.property.type);
+    this.addLabelValue(doc, 'Address:', contract.property.address);
+    this.addLabelValue(doc, 'City / Region:', `${contract.property.city}, ${contract.property.region}`);
+    this.addLabelValue(doc, 'Area:', `${contract.property.area} sqm`);
+    if (contract.property.bedrooms != null) {
+      this.addLabelValue(doc, 'Bedrooms:', String(contract.property.bedrooms));
+    }
+    if (contract.property.bathrooms != null) {
+      this.addLabelValue(doc, 'Bathrooms:', String(contract.property.bathrooms));
+    }
+    doc.moveDown(1);
+
+    // Client (party) info
+    this.addSection(doc, 'Client / Party');
+    this.addLabelValue(doc, 'Name:', `${contract.client.firstName} ${contract.client.lastName}`);
+    if (contract.client.email) {
+      this.addLabelValue(doc, 'Email:', contract.client.email);
+    }
+    this.addLabelValue(doc, 'Phone:', contract.client.phone);
+    if (contract.client.nationalId) {
+      this.addLabelValue(doc, 'National ID:', contract.client.nationalId);
+    }
+    doc.moveDown(1);
+
+    // Payment terms
+    if (contract.paymentTerms) {
+      this.addSection(doc, 'Payment Terms');
+      const terms = contract.paymentTerms as Record<string, unknown>;
+      if (terms.installments && Array.isArray(terms.installments)) {
+        const rows = (terms.installments as Array<{ amount?: number; dueDate?: string; description?: string }>).map(
+          (inst, i) => [
+            String(i + 1),
+            inst.description ?? `Installment ${i + 1}`,
+            inst.dueDate ? this.formatDate(inst.dueDate) : '-',
+            inst.amount ? this.formatCurrency(inst.amount) : '-',
+          ],
+        );
+        this.addTable(doc, ['#', 'Description', 'Due Date', 'Amount'], rows, [30, 200, 130, 130]);
+      } else {
+        doc
+          .fontSize(10)
+          .fillColor(this.textColor)
+          .text(JSON.stringify(terms, null, 2));
+      }
+      doc.moveDown(1);
+    }
+
+    // Notes
+    if (contract.notes) {
+      this.addSection(doc, 'Notes');
+      doc.fontSize(10).fillColor(this.textColor).text(contract.notes);
+      doc.moveDown(1);
+    }
+
+    // Signature area
+    doc.moveDown(2);
+    const pageWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+    const halfWidth = pageWidth / 2;
+    const sigY = doc.y;
+
+    doc
+      .fontSize(10)
+      .fillColor(this.textColor)
+      .text('Company Representative', doc.page.margins.left, sigY, {
+        width: halfWidth,
+        align: 'center',
+      });
+
+    doc.text('Client Signature', doc.page.margins.left + halfWidth, sigY, {
+      width: halfWidth,
+      align: 'center',
+    });
+
+    const lineY = sigY + 40;
+    doc
+      .strokeColor(this.borderColor)
+      .lineWidth(1)
+      .moveTo(doc.page.margins.left + 30, lineY)
+      .lineTo(doc.page.margins.left + halfWidth - 30, lineY)
+      .stroke();
+
+    doc
+      .moveTo(doc.page.margins.left + halfWidth + 30, lineY)
+      .lineTo(doc.page.margins.left + pageWidth - 30, lineY)
+      .stroke();
+
+    this.addFooter(doc);
+    return this.streamToBuffer(doc);
+  }
+}

--- a/src/pdf/templates/invoice.template.ts
+++ b/src/pdf/templates/invoice.template.ts
@@ -1,0 +1,121 @@
+import { Injectable } from '@nestjs/common';
+import { PdfBaseTemplate } from '../pdf-base.template.js';
+import type { Invoice, Contract, Property, Client } from '@prisma/client';
+
+type InvoiceWithRelations = Invoice & {
+  contract: Contract & {
+    property: Property;
+    client: Client;
+  };
+};
+
+@Injectable()
+export class InvoicePdfTemplate extends PdfBaseTemplate {
+  async generate(invoice: InvoiceWithRelations): Promise<Buffer> {
+    const doc = this.createDocument();
+
+    this.addHeader(doc, 'INVOICE / فاتورة');
+
+    const { contract } = invoice;
+    const pageWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+
+    // Invoice metadata (two-column layout)
+    const leftX = doc.page.margins.left;
+    const rightX = doc.page.margins.left + pageWidth / 2;
+    let y = doc.y;
+
+    doc.fontSize(10).fillColor('#718096').text('Invoice Number:', leftX, y);
+    doc.fillColor(this.textColor).text(invoice.invoiceNumber, leftX + 100, y);
+
+    doc.fillColor('#718096').text('Status:', rightX, y);
+    doc.fillColor(this.statusColor(invoice.status)).text(invoice.status, rightX + 100, y);
+
+    y += 18;
+    doc.fillColor('#718096').text('Issue Date:', leftX, y);
+    doc.fillColor(this.textColor).text(this.formatDate(invoice.createdAt), leftX + 100, y);
+
+    doc.fillColor('#718096').text('Due Date:', rightX, y);
+    doc.fillColor(this.textColor).text(this.formatDate(invoice.dueDate), rightX + 100, y);
+
+    if (invoice.paidDate) {
+      y += 18;
+      doc.fillColor('#718096').text('Paid Date:', leftX, y);
+      doc.fillColor(this.textColor).text(this.formatDate(invoice.paidDate), leftX + 100, y);
+
+      if (invoice.paymentMethod) {
+        doc.fillColor('#718096').text('Payment Method:', rightX, y);
+        doc.fillColor(this.textColor).text(invoice.paymentMethod, rightX + 100, y);
+      }
+    }
+
+    doc.y = y + 30;
+
+    // Bill To
+    this.addSection(doc, 'Bill To');
+    this.addLabelValue(doc, 'Name:', `${contract.client.firstName} ${contract.client.lastName}`);
+    if (contract.client.email) {
+      this.addLabelValue(doc, 'Email:', contract.client.email);
+    }
+    this.addLabelValue(doc, 'Phone:', contract.client.phone);
+    doc.moveDown(1);
+
+    // Property reference
+    this.addSection(doc, 'Property Reference');
+    this.addLabelValue(doc, 'Property:', contract.property.title);
+    this.addLabelValue(doc, 'Address:', `${contract.property.address}, ${contract.property.city}`);
+    this.addLabelValue(doc, 'Contract Type:', contract.type);
+    doc.moveDown(1);
+
+    // Amount table
+    this.addSection(doc, 'Amount Details');
+    this.addTable(
+      doc,
+      ['Description', 'Contract Total', 'Invoice Amount'],
+      [
+        [
+          `${contract.type} — ${contract.property.title}`,
+          this.formatCurrency(contract.totalAmount.toString()),
+          this.formatCurrency(invoice.amount.toString()),
+        ],
+      ],
+      [230, 130, 130],
+    );
+
+    // Total box
+    doc.moveDown(0.5);
+    const totalBoxX = doc.page.margins.left + pageWidth - 200;
+    const totalBoxY = doc.y;
+    doc
+      .rect(totalBoxX, totalBoxY, 200, 35)
+      .fill(this.primaryColor);
+    doc
+      .fontSize(12)
+      .fillColor('#ffffff')
+      .text('TOTAL DUE', totalBoxX + 10, totalBoxY + 10, { continued: true })
+      .text(`  ${this.formatCurrency(invoice.amount.toString())}`, { align: 'right' });
+
+    doc.y = totalBoxY + 50;
+
+    // Notes
+    if (invoice.notes) {
+      this.addSection(doc, 'Notes');
+      doc.fontSize(10).fillColor(this.textColor).text(invoice.notes);
+    }
+
+    this.addFooter(doc);
+    return this.streamToBuffer(doc);
+  }
+
+  private statusColor(status: string): string {
+    switch (status) {
+      case 'PAID':
+        return '#38a169';
+      case 'OVERDUE':
+        return '#e53e3e';
+      case 'CANCELLED':
+        return '#a0aec0';
+      default:
+        return '#dd6b20';
+    }
+  }
+}

--- a/src/pdf/templates/property.template.ts
+++ b/src/pdf/templates/property.template.ts
@@ -1,0 +1,91 @@
+import { Injectable } from '@nestjs/common';
+import { PdfBaseTemplate } from '../pdf-base.template.js';
+import type { Property, PropertyImage } from '@prisma/client';
+
+type PropertyWithImages = Property & {
+  images: PropertyImage[];
+};
+
+@Injectable()
+export class PropertyPdfTemplate extends PdfBaseTemplate {
+  async generate(property: PropertyWithImages): Promise<Buffer> {
+    const doc = this.createDocument();
+
+    this.addHeader(doc, 'PROPERTY LISTING / عقار');
+
+    // Title and price
+    doc
+      .fontSize(14)
+      .fillColor(this.primaryColor)
+      .text(property.title, { align: 'center' });
+    doc
+      .fontSize(16)
+      .fillColor(this.accentColor)
+      .text(this.formatCurrency(property.price.toString()), { align: 'center' });
+    doc.moveDown(1);
+
+    // Property details
+    this.addSection(doc, 'Property Details');
+    this.addLabelValue(doc, 'Type:', property.type);
+    this.addLabelValue(doc, 'Status:', property.status);
+    this.addLabelValue(doc, 'Area:', `${property.area} sqm`);
+    if (property.bedrooms != null) {
+      this.addLabelValue(doc, 'Bedrooms:', String(property.bedrooms));
+    }
+    if (property.bathrooms != null) {
+      this.addLabelValue(doc, 'Bathrooms:', String(property.bathrooms));
+    }
+    if (property.floor != null) {
+      this.addLabelValue(doc, 'Floor:', String(property.floor));
+    }
+    doc.moveDown(1);
+
+    // Location
+    this.addSection(doc, 'Location');
+    this.addLabelValue(doc, 'Address:', property.address);
+    this.addLabelValue(doc, 'City:', property.city);
+    this.addLabelValue(doc, 'Region:', property.region);
+    doc.moveDown(1);
+
+    // Features
+    if (property.features) {
+      this.addSection(doc, 'Features');
+      const features = property.features as Record<string, unknown>;
+      if (Array.isArray(features)) {
+        features.forEach((f) => {
+          doc.fontSize(10).fillColor(this.textColor).text(`• ${String(f)}`);
+        });
+      } else {
+        Object.entries(features).forEach(([key, val]) => {
+          this.addLabelValue(doc, `${key}:`, String(val));
+        });
+      }
+      doc.moveDown(1);
+    }
+
+    // Description
+    if (property.description) {
+      this.addSection(doc, 'Description');
+      doc.fontSize(10).fillColor(this.textColor).text(property.description);
+      doc.moveDown(1);
+    }
+
+    // Images list (URLs — actual image embedding would require fetching)
+    if (property.images.length > 0) {
+      this.addSection(doc, 'Photos');
+      doc
+        .fontSize(9)
+        .fillColor('#718096')
+        .text(`${property.images.length} photo(s) available. View online for full gallery.`);
+      property.images.forEach((img, i) => {
+        doc
+          .fontSize(8)
+          .fillColor(this.accentColor)
+          .text(`${i + 1}. ${img.caption ?? 'Photo'} — ${img.url}`);
+      });
+    }
+
+    this.addFooter(doc);
+    return this.streamToBuffer(doc);
+  }
+}

--- a/src/pdf/templates/report.template.ts
+++ b/src/pdf/templates/report.template.ts
@@ -1,0 +1,115 @@
+import { Injectable } from '@nestjs/common';
+import { PdfBaseTemplate } from '../pdf-base.template.js';
+
+export interface MonthlyRevenueData {
+  period: string;
+  totalInvoiced: number;
+  totalCollected: number;
+  totalOverdue: number;
+  invoicesByStatus: { status: string; count: number; amount: number }[];
+  topProperties: { title: string; revenue: number }[];
+}
+
+export interface AgentPerformanceData {
+  agentId: string;
+  agentName: string;
+  period: string;
+  leadsAssigned: number;
+  leadsWon: number;
+  leadsLost: number;
+  conversionRate: number;
+  contractsClosed: number;
+  totalRevenue: number;
+  activitiesLogged: number;
+}
+
+@Injectable()
+export class ReportPdfTemplate extends PdfBaseTemplate {
+  async generateMonthlyRevenue(data: MonthlyRevenueData): Promise<Buffer> {
+    const doc = this.createDocument();
+
+    this.addHeader(doc, `Monthly Revenue Report — ${data.period}`);
+
+    // Summary cards
+    this.addSection(doc, 'Revenue Summary');
+    this.addLabelValue(doc, 'Total Invoiced:', this.formatCurrency(data.totalInvoiced));
+    this.addLabelValue(doc, 'Total Collected:', this.formatCurrency(data.totalCollected));
+    this.addLabelValue(doc, 'Total Overdue:', this.formatCurrency(data.totalOverdue));
+    const collectionRate =
+      data.totalInvoiced > 0
+        ? ((data.totalCollected / data.totalInvoiced) * 100).toFixed(1)
+        : '0.0';
+    this.addLabelValue(doc, 'Collection Rate:', `${collectionRate}%`);
+    doc.moveDown(1);
+
+    // Invoices by status
+    if (data.invoicesByStatus.length > 0) {
+      this.addSection(doc, 'Invoices by Status');
+      this.addTable(
+        doc,
+        ['Status', 'Count', 'Amount'],
+        data.invoicesByStatus.map((s) => [
+          s.status,
+          String(s.count),
+          this.formatCurrency(s.amount),
+        ]),
+        [180, 100, 210],
+      );
+      doc.moveDown(1);
+    }
+
+    // Top properties
+    if (data.topProperties.length > 0) {
+      this.addSection(doc, 'Top Properties by Revenue');
+      this.addTable(
+        doc,
+        ['Property', 'Revenue'],
+        data.topProperties.map((p) => [p.title, this.formatCurrency(p.revenue)]),
+        [300, 190],
+      );
+    }
+
+    this.addFooter(doc);
+    return this.streamToBuffer(doc);
+  }
+
+  async generateAgentPerformance(data: AgentPerformanceData): Promise<Buffer> {
+    const doc = this.createDocument();
+
+    this.addHeader(doc, `Agent Performance Report — ${data.period}`);
+
+    this.addSection(doc, 'Agent Information');
+    this.addLabelValue(doc, 'Agent:', data.agentName);
+    this.addLabelValue(doc, 'Period:', data.period);
+    doc.moveDown(1);
+
+    this.addSection(doc, 'Lead Performance');
+    this.addTable(
+      doc,
+      ['Metric', 'Value'],
+      [
+        ['Leads Assigned', String(data.leadsAssigned)],
+        ['Leads Won', String(data.leadsWon)],
+        ['Leads Lost', String(data.leadsLost)],
+        ['Conversion Rate', `${data.conversionRate.toFixed(1)}%`],
+        ['Activities Logged', String(data.activitiesLogged)],
+      ],
+      [250, 240],
+    );
+    doc.moveDown(1);
+
+    this.addSection(doc, 'Revenue Performance');
+    this.addTable(
+      doc,
+      ['Metric', 'Value'],
+      [
+        ['Contracts Closed', String(data.contractsClosed)],
+        ['Total Revenue', this.formatCurrency(data.totalRevenue)],
+      ],
+      [250, 240],
+    );
+
+    this.addFooter(doc);
+    return this.streamToBuffer(doc);
+  }
+}


### PR DESCRIPTION
## Summary
- Implements PDF generation module using PDFKit (#29)
- **Contract PDF** — company header, property & client details, payment terms table, signature area
- **Invoice PDF** — two-column metadata layout, bill-to section, amount breakdown, total due box
- **Property listing PDF** — full property details for sharing with clients
- **Report PDFs** — monthly revenue summary and agent performance metrics

## Endpoints
- `GET /api/contracts/:id/pdf` — download contract PDF
- `GET /api/invoices/:id/pdf` — download invoice PDF
- `GET /api/properties/:id/pdf` — download property listing PDF
- `POST /api/reports/generate-pdf` — generate monthly revenue or agent performance report

## Details
- Reusable `PdfBaseTemplate` with header/footer, tables, currency formatting (EGP), Arabic bilingual headers
- All endpoints return `application/pdf` with proper Content-Disposition headers
- 6 controller unit tests passing

Closes #29

## Test plan
- [ ] Verify contract PDF renders with all fields populated
- [ ] Verify invoice PDF shows correct amounts and status colors
- [ ] Verify property listing PDF includes features and photo references
- [ ] Verify monthly revenue report aggregates invoices correctly
- [ ] Verify agent performance report pulls leads/contracts/activities
- [ ] Run `npx jest src/pdf` — all 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)