### PR TITLE
feat(activities): Activities Module — Audit Trail (#11)

### DIFF
--- a/src/activities/activities.controller.ts
+++ b/src/activities/activities.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseEnumPipe,
+  ParseIntPipe,
+  ParseUUIDPipe,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { ActivityEntityType } from '@prisma/client';
+import { ActivitiesService } from './activities.service.js';
+import { ActivityFilterDto } from './dto/activity-filter.dto.js';
+import { AuthGuard } from '../common/guards/auth.guard.js';
+import { Roles } from '../common/decorators/roles.decorator.js';
+
+@ApiTags('Activities')
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Controller('api/activities')
+export class ActivitiesController {
+  constructor(private readonly activitiesService: ActivitiesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all activities with filters and pagination' })
+  @ApiResponse({ status: 200, description: 'Paginated list of activities' })
+  findAll(@Query() filter: ActivityFilterDto) {
+    return this.activitiesService.findAll(filter);
+  }
+
+  @Get('recent')
+  @ApiOperation({ summary: 'Get recent activities for dashboard feed' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Number of recent activities (default 20)' })
+  @ApiResponse({ status: 200, description: 'Recent activities' })
+  findRecent(@Query('limit', new ParseIntPipe({ optional: true })) limit?: number) {
+    return this.activitiesService.findRecent(limit ?? 20);
+  }
+
+  @Get('entity/:type/:id')
+  @ApiOperation({ summary: 'Get activities for a specific entity' })
+  @ApiParam({ name: 'type', enum: ActivityEntityType, description: 'Entity type' })
+  @ApiParam({ name: 'id', description: 'Entity UUID' })
+  @ApiResponse({ status: 200, description: 'Activities for the entity' })
+  findByEntity(
+    @Param('type', new ParseEnumPipe(ActivityEntityType)) type: ActivityEntityType,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query() filter: ActivityFilterDto,
+  ) {
+    return this.activitiesService.findByEntity(type, id, filter);
+  }
+
+  @Get('user/:userId')
+  @ApiOperation({ summary: 'Get activities by a user' })
+  @ApiParam({ name: 'userId', description: 'User UUID' })
+  @ApiResponse({ status: 200, description: 'Activities performed by the user' })
+  findByUser(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query() filter: ActivityFilterDto,
+  ) {
+    return this.activitiesService.findByUser(userId, filter);
+  }
+
+  @Get('purge/:days')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Purge activities older than N days (admin only)' })
+  @ApiParam({ name: 'days', type: Number, description: 'Delete activities older than this many days' })
+  @ApiResponse({ status: 200, description: 'Purge result with count of deleted records' })
+  purge(@Param('days', ParseIntPipe) days: number) {
+    return this.activitiesService.purgeOlderThan(days);
+  }
+}

--- a/src/activities/activities.module.ts
+++ b/src/activities/activities.module.ts
@@ -1,0 +1,12 @@
+import { Global, Module } from '@nestjs/common';
+import { ActivitiesService } from './activities.service.js';
+import { ActivitiesController } from './activities.controller.js';
+import { ActivityInterceptor } from './activity.interceptor.js';
+
+@Global()
+@Module({
+  controllers: [ActivitiesController],
+  providers: [ActivitiesService, ActivityInterceptor],
+  exports: [ActivitiesService, ActivityInterceptor],
+})
+export class ActivitiesModule {}

--- a/src/activities/activities.service.ts
+++ b/src/activities/activities.service.ts
@@ -1,0 +1,142 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma, ActivityEntityType } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CreateActivityDto } from './dto/create-activity.dto.js';
+import { ActivityFilterDto } from './dto/activity-filter.dto.js';
+import { paginate, type PaginatedResult } from '../common/dto/pagination.dto.js';
+
+@Injectable()
+export class ActivitiesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Log a new activity. Used both by the controller and the interceptor.
+   */
+  async log(dto: CreateActivityDto) {
+    return this.prisma.activity.create({ data: dto });
+  }
+
+  /**
+   * List all activities with filters and pagination.
+   */
+  async findAll(filter: ActivityFilterDto): Promise<PaginatedResult<any>> {
+    const where = this.buildWhereClause(filter);
+
+    const [data, total] = await Promise.all([
+      this.prisma.activity.findMany({
+        where,
+        skip: filter.skip,
+        take: filter.limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.activity.count({ where }),
+    ]);
+
+    return paginate(data, total, filter);
+  }
+
+  /**
+   * Get activities for a specific entity.
+   */
+  async findByEntity(
+    entityType: ActivityEntityType,
+    entityId: string,
+    filter: ActivityFilterDto,
+  ): Promise<PaginatedResult<any>> {
+    const where: Prisma.ActivityWhereInput = {
+      entityType,
+      entityId,
+      ...this.buildDateFilter(filter),
+    };
+
+    const [data, total] = await Promise.all([
+      this.prisma.activity.findMany({
+        where,
+        skip: filter.skip,
+        take: filter.limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.activity.count({ where }),
+    ]);
+
+    return paginate(data, total, filter);
+  }
+
+  /**
+   * Get activities performed by a specific user.
+   */
+  async findByUser(
+    userId: string,
+    filter: ActivityFilterDto,
+  ): Promise<PaginatedResult<any>> {
+    const where: Prisma.ActivityWhereInput = {
+      performedBy: userId,
+      ...this.buildDateFilter(filter),
+    };
+
+    const [data, total] = await Promise.all([
+      this.prisma.activity.findMany({
+        where,
+        skip: filter.skip,
+        take: filter.limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.activity.count({ where }),
+    ]);
+
+    return paginate(data, total, filter);
+  }
+
+  /**
+   * Get recent activities for dashboard feed.
+   */
+  async findRecent(limit = 20) {
+    return this.prisma.activity.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+  }
+
+  /**
+   * Delete activities older than the given number of days (retention policy).
+   */
+  async purgeOlderThan(days: number) {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+
+    const result = await this.prisma.activity.deleteMany({
+      where: { createdAt: { lt: cutoff } },
+    });
+
+    return { deleted: result.count, before: cutoff.toISOString() };
+  }
+
+  private buildWhereClause(filter: ActivityFilterDto): Prisma.ActivityWhereInput {
+    const where: Prisma.ActivityWhereInput = {};
+
+    if (filter.type) where.type = filter.type;
+    if (filter.entityType) where.entityType = filter.entityType;
+    if (filter.entityId) where.entityId = filter.entityId;
+    if (filter.performedBy) where.performedBy = filter.performedBy;
+
+    if (filter.search) {
+      where.description = { contains: filter.search, mode: 'insensitive' };
+    }
+
+    Object.assign(where, this.buildDateFilter(filter));
+
+    return where;
+  }
+
+  private buildDateFilter(filter: ActivityFilterDto): Prisma.ActivityWhereInput {
+    const dateFilter: Prisma.ActivityWhereInput = {};
+
+    if (filter.from || filter.to) {
+      dateFilter.createdAt = {};
+      if (filter.from) (dateFilter.createdAt as any).gte = new Date(filter.from);
+      if (filter.to) (dateFilter.createdAt as any).lte = new Date(filter.to);
+    }
+
+    return dateFilter;
+  }
+}

--- a/src/activities/activity.interceptor.ts
+++ b/src/activities/activity.interceptor.ts
@@ -1,0 +1,96 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable, tap } from 'rxjs';
+import type { Request } from 'express';
+import { ActivitiesService } from './activities.service.js';
+import type { AuthenticatedUser } from '../common/decorators/current-user.decorator.js';
+import { ActivityEntityType } from '@prisma/client';
+
+/**
+ * Metadata key for @LogActivity decorator.
+ */
+export const LOG_ACTIVITY_KEY = 'log_activity';
+
+export interface LogActivityOptions {
+  entityType: ActivityEntityType;
+  /** Extract entity ID from request params — defaults to 'id' */
+  idParam?: string;
+}
+
+/**
+ * Decorator to mark a controller method for automatic activity logging.
+ *
+ * Usage:
+ *   @LogActivity({ entityType: ActivityEntityType.PROPERTY })
+ *   @Post()
+ *   create(...) { ... }
+ */
+export function LogActivity(options: LogActivityOptions): MethodDecorator {
+  return (target, key, descriptor) => {
+    Reflect.defineMetadata(LOG_ACTIVITY_KEY, options, descriptor.value as object);
+    return descriptor;
+  };
+}
+
+const METHOD_TO_ACTION: Record<string, string> = {
+  POST: 'CREATE',
+  PUT: 'UPDATE',
+  PATCH: 'UPDATE',
+  DELETE: 'DELETE',
+};
+
+@Injectable()
+export class ActivityInterceptor implements NestInterceptor {
+  constructor(
+    private readonly activitiesService: ActivitiesService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const options = this.reflector.get<LogActivityOptions | undefined>(
+      LOG_ACTIVITY_KEY,
+      context.getHandler(),
+    );
+
+    if (!options) {
+      return next.handle();
+    }
+
+    const request = context.switchToHttp().getRequest<Request & { user?: AuthenticatedUser }>();
+    const method = request.method;
+    const action = METHOD_TO_ACTION[method] ?? method;
+    const idParam = options.idParam ?? 'id';
+    const user = request.user;
+
+    return next.handle().pipe(
+      tap((responseBody) => {
+        const rawEntityId =
+          request.params[idParam] ??
+          (responseBody && typeof responseBody === 'object' ? responseBody.id : undefined);
+        const entityId = Array.isArray(rawEntityId) ? rawEntityId[0] : rawEntityId;
+
+        if (!entityId) return;
+
+        const description = `${action} ${options.entityType.toLowerCase()} ${entityId}`;
+
+        this.activitiesService
+          .log({
+            type: action,
+            description,
+            entityType: options.entityType,
+            entityId,
+            performedBy: user?.sub ?? 'system',
+            metadata: action === 'CREATE' ? { created: true } : undefined,
+          })
+          .catch(() => {
+            // Activity logging should never break the main flow
+          });
+      }),
+    );
+  }
+}

--- a/src/activities/dto/activity-filter.dto.ts
+++ b/src/activities/dto/activity-filter.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, IsDateString } from 'class-validator';
+import { ActivityEntityType } from '@prisma/client';
+import { PaginationDto } from '../../common/dto/pagination.dto.js';
+
+export class ActivityFilterDto extends PaginationDto {
+  @ApiPropertyOptional({ description: 'Filter by activity type (e.g. CREATE, UPDATE, DELETE)' })
+  @IsOptional()
+  @IsString()
+  type?: string;
+
+  @ApiPropertyOptional({ enum: ActivityEntityType, description: 'Filter by entity type' })
+  @IsOptional()
+  @IsEnum(ActivityEntityType)
+  entityType?: ActivityEntityType;
+
+  @ApiPropertyOptional({ description: 'Filter by entity ID' })
+  @IsOptional()
+  @IsString()
+  entityId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by performer ID' })
+  @IsOptional()
+  @IsString()
+  performedBy?: string;
+
+  @ApiPropertyOptional({ description: 'Start date filter (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @ApiPropertyOptional({ description: 'End date filter (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+}

--- a/src/activities/dto/create-activity.dto.ts
+++ b/src/activities/dto/create-activity.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
+import { ActivityEntityType } from '@prisma/client';
+
+export class CreateActivityDto {
+  @ApiProperty({ description: 'Activity type (e.g. CREATE, UPDATE, DELETE, STATUS_CHANGE)' })
+  @IsNotEmpty()
+  @IsString()
+  type: string;
+
+  @ApiProperty({ description: 'Human-readable description of the activity' })
+  @IsNotEmpty()
+  @IsString()
+  description: string;
+
+  @ApiProperty({ enum: ActivityEntityType, description: 'Type of entity this activity relates to' })
+  @IsNotEmpty()
+  @IsEnum(ActivityEntityType)
+  entityType: ActivityEntityType;
+
+  @ApiProperty({ description: 'UUID of the related entity' })
+  @IsNotEmpty()
+  @IsString()
+  entityId: string;
+
+  @ApiProperty({ description: 'UUID of the user who performed the action' })
+  @IsNotEmpty()
+  @IsString()
+  performedBy: string;
+
+  @ApiPropertyOptional({ description: 'Additional metadata (e.g. old/new values)' })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { ContractsModule } from './contracts/contracts.module.js';
 import { InvoicesModule } from './invoices/invoices.module.js';
 import { LeadsModule } from './leads/leads.module.js';
 import { PdfModule } from './pdf/pdf.module.js';
+import { ActivitiesModule } from './activities/activities.module.js';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { PdfModule } from './pdf/pdf.module.js';
     InvoicesModule,
     LeadsModule,
     PdfModule,
+    ActivitiesModule,
   ],
   providers: [
     {


### PR DESCRIPTION
## Summary
- Implements the **Activities Module** (Issue #11) — a global audit trail for all CRM actions
- **Endpoints:** list all activities (filtered/paginated), by entity, by user, recent feed, and admin purge
- **ActivityInterceptor** + `@LogActivity()` decorator for auto-logging CRUD operations on any controller
- **Retention policy** via `GET /api/activities/purge/:days` (admin-only)
- Module is `@Global()` so any module can inject `ActivitiesService` to log custom events

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/activities` | List activities with filters & pagination |
| GET | `/api/activities/recent` | Recent activities for dashboard feed |
| GET | `/api/activities/entity/:type/:id` | Activities for a specific entity |
| GET | `/api/activities/user/:userId` | Activities by user |
| GET | `/api/activities/purge/:days` | Delete old activities (admin) |

## Test plan
- [ ] Verify `tsc --noEmit` passes (confirmed locally)
- [ ] Test all 5 endpoints via Swagger / curl
- [ ] Verify `@LogActivity()` decorator auto-logs on decorated controllers
- [ ] Verify retention purge deletes correct records

Closes #11