### PR TITLE
feat(dashboard): Dashboard module — Stats & Analytics APIs (#13)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { LeadsModule } from './leads/leads.module.js';
 import { PdfModule } from './pdf/pdf.module.js';
 import { ActivitiesModule } from './activities/activities.module.js';
 import { UploadsModule } from './uploads/uploads.module.js';
+import { DashboardModule } from './dashboard/dashboard.module.js';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { UploadsModule } from './uploads/uploads.module.js';
     PdfModule,
     ActivitiesModule,
     UploadsModule,
+    DashboardModule,
   ],
   providers: [
     {

--- a/src/dashboard/dashboard.controller.spec.ts
+++ b/src/dashboard/dashboard.controller.spec.ts
@@ -1,0 +1,201 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DashboardController } from './dashboard.controller.js';
+import { DashboardService } from './dashboard.service.js';
+import { DateRangePreset } from './dto/date-range.dto.js';
+import type { AuthenticatedUser } from '../common/decorators/current-user.decorator.js';
+
+const mockService = {
+  getAdminOverview: jest.fn(),
+  getAdminRevenue: jest.fn(),
+  getAdminLeads: jest.fn(),
+  getAdminProperties: jest.fn(),
+  getAdminAgents: jest.fn(),
+  getAdminRecent: jest.fn(),
+  getAgentOverview: jest.fn(),
+  getAgentLeads: jest.fn(),
+  getAgentFollowUps: jest.fn(),
+  getAgentPerformance: jest.fn(),
+};
+
+const adminUser: AuthenticatedUser = {
+  sub: 'admin-001',
+  email: 'admin@test.com',
+  roles: ['admin'],
+};
+
+const agentUser: AuthenticatedUser = {
+  sub: 'agent-001',
+  email: 'agent@test.com',
+  roles: ['agent'],
+};
+
+describe('DashboardController', () => {
+  let controller: DashboardController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DashboardController],
+      providers: [{ provide: DashboardService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get<DashboardController>(DashboardController);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  // ─── Admin Endpoints ────────────────────────────────────────────────
+
+  describe('getAdminOverview', () => {
+    it('should return overview statistics', async () => {
+      const overview = {
+        totals: { properties: 50, clients: 100, leads: 200, contracts: 30, revenue: 5000000 },
+        period: { newProperties: 5, newClients: 10, newLeads: 20, start: new Date(), end: new Date() },
+      };
+      mockService.getAdminOverview.mockResolvedValue(overview);
+
+      const dateRange = { range: DateRangePreset.THIS_MONTH };
+      const result = await controller.getAdminOverview(dateRange);
+      expect(result.totals.properties).toBe(50);
+      expect(mockService.getAdminOverview).toHaveBeenCalledWith(dateRange);
+    });
+  });
+
+  describe('getAdminRevenue', () => {
+    it('should return revenue timeline with comparison', async () => {
+      const revenue = {
+        timeline: [{ date: '2026-03-01', amount: 100000 }],
+        total: 500000,
+        previousPeriodTotal: 400000,
+        changePercent: 25,
+        period: { start: new Date(), end: new Date() },
+      };
+      mockService.getAdminRevenue.mockResolvedValue(revenue);
+
+      const dateRange = { range: DateRangePreset.THIS_MONTH };
+      const result = await controller.getAdminRevenue(dateRange);
+      expect(result.total).toBe(500000);
+      expect(result.changePercent).toBe(25);
+      expect(mockService.getAdminRevenue).toHaveBeenCalledWith(dateRange);
+    });
+  });
+
+  describe('getAdminLeads', () => {
+    it('should return lead pipeline summary', async () => {
+      const leads = {
+        pipeline: [{ status: 'NEW', count: 10 }, { status: 'WON', count: 5 }],
+        byPriority: [{ priority: 'HIGH', count: 3 }],
+        newLeadsInPeriod: 10,
+        wonLeadsInPeriod: 5,
+        conversionRate: 8.33,
+      };
+      mockService.getAdminLeads.mockResolvedValue(leads);
+
+      const result = await controller.getAdminLeads({ range: DateRangePreset.THIS_MONTH });
+      expect(result.pipeline).toHaveLength(2);
+      expect(result.conversionRate).toBe(8.33);
+    });
+  });
+
+  describe('getAdminProperties', () => {
+    it('should return property breakdowns', async () => {
+      const properties = {
+        byStatus: [{ status: 'AVAILABLE', count: 30 }],
+        byType: [{ type: 'APARTMENT', count: 20 }],
+        total: 50,
+      };
+      mockService.getAdminProperties.mockResolvedValue(properties);
+
+      const result = await controller.getAdminProperties();
+      expect(result.total).toBe(50);
+      expect(mockService.getAdminProperties).toHaveBeenCalled();
+    });
+  });
+
+  describe('getAdminAgents', () => {
+    it('should return agent performance data', async () => {
+      const agents = {
+        agents: [{ agentId: 'agent-001', leadsWon: 5, totalLeads: 20, revenue: 1000000 }],
+        period: { start: new Date(), end: new Date() },
+      };
+      mockService.getAdminAgents.mockResolvedValue(agents);
+
+      const result = await controller.getAdminAgents({ range: DateRangePreset.THIS_MONTH });
+      expect(result.agents).toHaveLength(1);
+      expect(result.agents[0].leadsWon).toBe(5);
+    });
+  });
+
+  describe('getAdminRecent', () => {
+    it('should return recent activities', async () => {
+      const activities = [
+        { id: 'act-001', type: 'CREATED', description: 'New property added', createdAt: new Date() },
+      ];
+      mockService.getAdminRecent.mockResolvedValue(activities);
+
+      const result = await controller.getAdminRecent();
+      expect(result).toHaveLength(1);
+      expect(mockService.getAdminRecent).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Agent Endpoints ────────────────────────────────────────────────
+
+  describe('getAgentOverview', () => {
+    it('should return overview scoped to agent', async () => {
+      const overview = { properties: 5, clients: 10, leads: 15, upcomingFollowUps: 3 };
+      mockService.getAgentOverview.mockResolvedValue(overview);
+
+      const result = await controller.getAgentOverview(agentUser);
+      expect(result.properties).toBe(5);
+      expect(mockService.getAgentOverview).toHaveBeenCalledWith('agent-001');
+    });
+  });
+
+  describe('getAgentLeads', () => {
+    it('should return agent lead pipeline', async () => {
+      const leads = {
+        pipeline: [{ status: 'NEW', count: 3 }],
+        total: 10,
+      };
+      mockService.getAgentLeads.mockResolvedValue(leads);
+
+      const result = await controller.getAgentLeads(agentUser);
+      expect(result.total).toBe(10);
+      expect(mockService.getAgentLeads).toHaveBeenCalledWith('agent-001');
+    });
+  });
+
+  describe('getAgentFollowUps', () => {
+    it('should return overdue and upcoming follow-ups', async () => {
+      const followUps = {
+        overdue: [{ id: 'lead-001', nextFollowUp: new Date() }],
+        upcoming: [{ id: 'lead-002', nextFollowUp: new Date() }],
+      };
+      mockService.getAgentFollowUps.mockResolvedValue(followUps);
+
+      const result = await controller.getAgentFollowUps(agentUser);
+      expect(result.overdue).toHaveLength(1);
+      expect(result.upcoming).toHaveLength(1);
+      expect(mockService.getAgentFollowUps).toHaveBeenCalledWith('agent-001');
+    });
+  });
+
+  describe('getAgentPerformance', () => {
+    it('should return this month vs last month comparison', async () => {
+      const performance = {
+        thisMonth: { leads: 10, won: 3, revenue: 500000 },
+        lastMonth: { leads: 8, won: 2, revenue: 400000 },
+        change: { leads: 25, won: 50, revenue: 25 },
+      };
+      mockService.getAgentPerformance.mockResolvedValue(performance);
+
+      const result = await controller.getAgentPerformance(agentUser);
+      expect(result.thisMonth.leads).toBe(10);
+      expect(result.change.leads).toBe(25);
+      expect(mockService.getAgentPerformance).toHaveBeenCalledWith('agent-001');
+    });
+  });
+});

--- a/src/dashboard/dashboard.controller.ts
+++ b/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,109 @@
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { DashboardService } from './dashboard.service.js';
+import { DateRangeDto } from './dto/date-range.dto.js';
+import { CurrentUser, type AuthenticatedUser } from '../common/decorators/current-user.decorator.js';
+import { Roles } from '../common/decorators/roles.decorator.js';
+import { AuthGuard } from '../common/guards/auth.guard.js';
+
+@ApiTags('Dashboard')
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Controller('api/dashboard')
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  // ─── Admin Dashboard ───────────────────────────────────────────────
+
+  @Get('admin/overview')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Admin overview — totals and period stats' })
+  @ApiResponse({ status: 200, description: 'Overview statistics' })
+  getAdminOverview(@Query() dateRange: DateRangeDto) {
+    return this.dashboardService.getAdminOverview(dateRange);
+  }
+
+  @Get('admin/revenue')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Revenue over time with period comparison' })
+  @ApiResponse({ status: 200, description: 'Revenue timeline and totals' })
+  getAdminRevenue(@Query() dateRange: DateRangeDto) {
+    return this.dashboardService.getAdminRevenue(dateRange);
+  }
+
+  @Get('admin/leads')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Lead pipeline summary' })
+  @ApiResponse({ status: 200, description: 'Lead pipeline statistics' })
+  getAdminLeads(@Query() dateRange: DateRangeDto) {
+    return this.dashboardService.getAdminLeads(dateRange);
+  }
+
+  @Get('admin/properties')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Properties breakdown by status and type' })
+  @ApiResponse({ status: 200, description: 'Property statistics' })
+  getAdminProperties() {
+    return this.dashboardService.getAdminProperties();
+  }
+
+  @Get('admin/agents')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Agent performance — leads won and revenue' })
+  @ApiResponse({ status: 200, description: 'Agent performance data' })
+  getAdminAgents(@Query() dateRange: DateRangeDto) {
+    return this.dashboardService.getAdminAgents(dateRange);
+  }
+
+  @Get('admin/recent')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Recent activities feed' })
+  @ApiResponse({ status: 200, description: 'Recent activity list' })
+  getAdminRecent() {
+    return this.dashboardService.getAdminRecent();
+  }
+
+  // ─── Agent Dashboard ───────────────────────────────────────────────
+
+  @Get('agent/overview')
+  @Roles('admin', 'manager', 'agent')
+  @ApiOperation({ summary: 'Agent overview — my properties, clients, leads, tasks' })
+  @ApiResponse({ status: 200, description: 'Agent overview statistics' })
+  getAgentOverview(@CurrentUser() user: AuthenticatedUser) {
+    return this.dashboardService.getAgentOverview(user.sub);
+  }
+
+  @Get('agent/leads')
+  @Roles('admin', 'manager', 'agent')
+  @ApiOperation({ summary: 'Agent lead pipeline' })
+  @ApiResponse({ status: 200, description: 'Agent lead pipeline' })
+  getAgentLeads(@CurrentUser() user: AuthenticatedUser) {
+    return this.dashboardService.getAgentLeads(user.sub);
+  }
+
+  @Get('agent/follow-ups')
+  @Roles('admin', 'manager', 'agent')
+  @ApiOperation({ summary: 'Upcoming and overdue follow-ups' })
+  @ApiResponse({ status: 200, description: 'Follow-up lists' })
+  getAgentFollowUps(@CurrentUser() user: AuthenticatedUser) {
+    return this.dashboardService.getAgentFollowUps(user.sub);
+  }
+
+  @Get('agent/performance')
+  @Roles('admin', 'manager', 'agent')
+  @ApiOperation({ summary: 'Agent performance — this month vs last month' })
+  @ApiResponse({ status: 200, description: 'Performance comparison' })
+  getAgentPerformance(@CurrentUser() user: AuthenticatedUser) {
+    return this.dashboardService.getAgentPerformance(user.sub);
+  }
+}

--- a/src/dashboard/dashboard.module.ts
+++ b/src/dashboard/dashboard.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DashboardController } from './dashboard.controller.js';
+import { DashboardService } from './dashboard.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/src/dashboard/dashboard.service.spec.ts
+++ b/src/dashboard/dashboard.service.spec.ts
@@ -1,0 +1,141 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DashboardService } from './dashboard.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { DateRangePreset } from './dto/date-range.dto.js';
+
+const mockPrisma = {
+  property: { count: jest.fn(), groupBy: jest.fn() },
+  client: { count: jest.fn() },
+  lead: { count: jest.fn(), groupBy: jest.fn(), findMany: jest.fn() },
+  contract: { count: jest.fn(), findMany: jest.fn(), aggregate: jest.fn() },
+  invoice: { aggregate: jest.fn(), findMany: jest.fn() },
+  activity: { findMany: jest.fn() },
+};
+
+describe('DashboardService', () => {
+  let service: DashboardService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DashboardService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<DashboardService>(DashboardService);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getAdminOverview', () => {
+    it('should return totals and period counts', async () => {
+      mockPrisma.property.count.mockResolvedValueOnce(50).mockResolvedValueOnce(5);
+      mockPrisma.client.count.mockResolvedValueOnce(100).mockResolvedValueOnce(10);
+      mockPrisma.lead.count.mockResolvedValueOnce(200).mockResolvedValueOnce(20);
+      mockPrisma.contract.count.mockResolvedValue(30);
+      mockPrisma.invoice.aggregate.mockResolvedValue({ _sum: { amount: 5000000 } });
+
+      const result = await service.getAdminOverview({ range: DateRangePreset.THIS_MONTH });
+
+      expect(result.totals.properties).toBe(50);
+      expect(result.totals.clients).toBe(100);
+      expect(result.totals.revenue).toBe(5000000);
+      expect(result.period.newProperties).toBe(5);
+    });
+  });
+
+  describe('getAdminProperties', () => {
+    it('should return breakdowns by status and type', async () => {
+      mockPrisma.property.groupBy
+        .mockResolvedValueOnce([{ status: 'AVAILABLE', _count: 30 }])
+        .mockResolvedValueOnce([{ type: 'APARTMENT', _count: 20 }]);
+
+      const result = await service.getAdminProperties();
+
+      expect(result.byStatus).toHaveLength(1);
+      expect(result.byType).toHaveLength(1);
+      expect(result.total).toBe(30);
+    });
+  });
+
+  describe('getAdminRecent', () => {
+    it('should return recent activities', async () => {
+      const activities = [{ id: 'act-1', type: 'CREATED', createdAt: new Date() }];
+      mockPrisma.activity.findMany.mockResolvedValue(activities);
+
+      const result = await service.getAdminRecent(10);
+
+      expect(result).toHaveLength(1);
+      expect(mockPrisma.activity.findMany).toHaveBeenCalledWith({
+        orderBy: { createdAt: 'desc' },
+        take: 10,
+      });
+    });
+  });
+
+  describe('getAgentOverview', () => {
+    it('should return counts scoped to agent', async () => {
+      mockPrisma.property.count.mockResolvedValue(5);
+      mockPrisma.client.count.mockResolvedValue(10);
+      mockPrisma.lead.count.mockResolvedValueOnce(15).mockResolvedValueOnce(3);
+
+      const result = await service.getAgentOverview('agent-001');
+
+      expect(result.properties).toBe(5);
+      expect(result.clients).toBe(10);
+      expect(result.leads).toBe(15);
+      expect(result.upcomingFollowUps).toBe(3);
+    });
+  });
+
+  describe('getAgentLeads', () => {
+    it('should return pipeline grouped by status', async () => {
+      mockPrisma.lead.groupBy.mockResolvedValue([
+        { status: 'NEW', _count: 3 },
+        { status: 'CONTACTED', _count: 2 },
+      ]);
+
+      const result = await service.getAgentLeads('agent-001');
+
+      expect(result.pipeline).toHaveLength(2);
+      expect(result.total).toBe(5);
+    });
+  });
+
+  describe('getAgentFollowUps', () => {
+    it('should return overdue and upcoming follow-ups', async () => {
+      mockPrisma.lead.findMany
+        .mockResolvedValueOnce([{ id: 'lead-1' }])
+        .mockResolvedValueOnce([{ id: 'lead-2' }, { id: 'lead-3' }]);
+
+      const result = await service.getAgentFollowUps('agent-001');
+
+      expect(result.overdue).toHaveLength(1);
+      expect(result.upcoming).toHaveLength(2);
+    });
+  });
+
+  describe('getAgentPerformance', () => {
+    it('should compare this month vs last month', async () => {
+      mockPrisma.lead.count
+        .mockResolvedValueOnce(10)  // this month leads
+        .mockResolvedValueOnce(8)   // last month leads
+        .mockResolvedValueOnce(3)   // this month won
+        .mockResolvedValueOnce(2);  // last month won
+      mockPrisma.contract.aggregate
+        .mockResolvedValueOnce({ _sum: { totalAmount: 500000 } })
+        .mockResolvedValueOnce({ _sum: { totalAmount: 400000 } });
+
+      const result = await service.getAgentPerformance('agent-001');
+
+      expect(result.thisMonth.leads).toBe(10);
+      expect(result.lastMonth.leads).toBe(8);
+      expect(result.change.leads).toBe(25);
+      expect(result.change.revenue).toBe(25);
+    });
+  });
+});

--- a/src/dashboard/dashboard.service.ts
+++ b/src/dashboard/dashboard.service.ts
@@ -1,0 +1,421 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma, LeadStatus, ContractStatus, InvoiceStatus, PropertyStatus } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { DateRangeDto, DateRangePreset } from './dto/date-range.dto.js';
+
+@Injectable()
+export class DashboardService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ─── Admin Endpoints ────────────────────────────────────────────────
+
+  async getAdminOverview(dateRange: DateRangeDto) {
+    const { start, end } = this.resolveDateRange(dateRange);
+    const dateFilter = { gte: start, lte: end };
+
+    const [
+      totalProperties,
+      totalClients,
+      totalLeads,
+      totalContracts,
+      revenueResult,
+      newPropertiesCount,
+      newClientsCount,
+      newLeadsCount,
+    ] = await Promise.all([
+      this.prisma.property.count(),
+      this.prisma.client.count(),
+      this.prisma.lead.count(),
+      this.prisma.contract.count(),
+      this.prisma.invoice.aggregate({
+        _sum: { amount: true },
+        where: { status: InvoiceStatus.PAID },
+      }),
+      this.prisma.property.count({ where: { createdAt: dateFilter } }),
+      this.prisma.client.count({ where: { createdAt: dateFilter } }),
+      this.prisma.lead.count({ where: { createdAt: dateFilter } }),
+    ]);
+
+    return {
+      totals: {
+        properties: totalProperties,
+        clients: totalClients,
+        leads: totalLeads,
+        contracts: totalContracts,
+        revenue: revenueResult._sum.amount ?? 0,
+      },
+      period: {
+        newProperties: newPropertiesCount,
+        newClients: newClientsCount,
+        newLeads: newLeadsCount,
+        start,
+        end,
+      },
+    };
+  }
+
+  async getAdminRevenue(dateRange: DateRangeDto) {
+    const { start, end } = this.resolveDateRange(dateRange);
+
+    const paidInvoices = await this.prisma.invoice.findMany({
+      where: {
+        status: InvoiceStatus.PAID,
+        paidDate: { gte: start, lte: end },
+      },
+      select: { amount: true, paidDate: true },
+      orderBy: { paidDate: 'asc' },
+    });
+
+    // Group by date (YYYY-MM-DD)
+    const dailyRevenue: Record<string, number> = {};
+    for (const inv of paidInvoices) {
+      const day = inv.paidDate!.toISOString().slice(0, 10);
+      dailyRevenue[day] = (dailyRevenue[day] ?? 0) + Number(inv.amount);
+    }
+
+    // Previous period for comparison
+    const periodMs = end.getTime() - start.getTime();
+    const prevStart = new Date(start.getTime() - periodMs);
+    const prevEnd = new Date(start.getTime() - 1);
+
+    const [currentTotal, previousTotal] = await Promise.all([
+      this.prisma.invoice.aggregate({
+        _sum: { amount: true },
+        where: { status: InvoiceStatus.PAID, paidDate: { gte: start, lte: end } },
+      }),
+      this.prisma.invoice.aggregate({
+        _sum: { amount: true },
+        where: { status: InvoiceStatus.PAID, paidDate: { gte: prevStart, lte: prevEnd } },
+      }),
+    ]);
+
+    const current = Number(currentTotal._sum.amount ?? 0);
+    const previous = Number(previousTotal._sum.amount ?? 0);
+    const changePercent = previous > 0 ? ((current - previous) / previous) * 100 : null;
+
+    return {
+      timeline: Object.entries(dailyRevenue).map(([date, amount]) => ({ date, amount })),
+      total: current,
+      previousPeriodTotal: previous,
+      changePercent: changePercent !== null ? Math.round(changePercent * 100) / 100 : null,
+      period: { start, end },
+    };
+  }
+
+  async getAdminLeads(dateRange: DateRangeDto) {
+    const { start, end } = this.resolveDateRange(dateRange);
+
+    const [byStatus, byPriority, newLeads, wonLeads] = await Promise.all([
+      this.prisma.lead.groupBy({
+        by: ['status'],
+        _count: true,
+      }),
+      this.prisma.lead.groupBy({
+        by: ['priority'],
+        _count: true,
+      }),
+      this.prisma.lead.count({
+        where: { createdAt: { gte: start, lte: end } },
+      }),
+      this.prisma.lead.count({
+        where: { status: LeadStatus.WON, updatedAt: { gte: start, lte: end } },
+      }),
+    ]);
+
+    const total = byStatus.reduce((sum, g) => sum + g._count, 0);
+    const conversionRate = total > 0
+      ? Math.round((byStatus.find((g) => g.status === LeadStatus.WON)?._count ?? 0) / total * 10000) / 100
+      : 0;
+
+    return {
+      pipeline: byStatus.map((g) => ({ status: g.status, count: g._count })),
+      byPriority: byPriority.map((g) => ({ priority: g.priority, count: g._count })),
+      newLeadsInPeriod: newLeads,
+      wonLeadsInPeriod: wonLeads,
+      conversionRate,
+    };
+  }
+
+  async getAdminProperties() {
+    const [byStatus, byType] = await Promise.all([
+      this.prisma.property.groupBy({
+        by: ['status'],
+        _count: true,
+      }),
+      this.prisma.property.groupBy({
+        by: ['type'],
+        _count: true,
+      }),
+    ]);
+
+    return {
+      byStatus: byStatus.map((g) => ({ status: g.status, count: g._count })),
+      byType: byType.map((g) => ({ type: g.type, count: g._count })),
+      total: byStatus.reduce((sum, g) => sum + g._count, 0),
+    };
+  }
+
+  async getAdminAgents(dateRange: DateRangeDto) {
+    const { start, end } = this.resolveDateRange(dateRange);
+
+    // Get leads won per agent in the period
+    const wonLeads = await this.prisma.lead.groupBy({
+      by: ['assignedAgentId'],
+      where: {
+        status: LeadStatus.WON,
+        updatedAt: { gte: start, lte: end },
+        assignedAgentId: { not: null },
+      },
+      _count: true,
+    });
+
+    // Get revenue per agent (through contracts)
+    const contracts = await this.prisma.contract.findMany({
+      where: {
+        status: { in: [ContractStatus.ACTIVE, ContractStatus.COMPLETED] },
+        createdAt: { gte: start, lte: end },
+        agentId: { not: null },
+      },
+      select: { agentId: true, totalAmount: true },
+    });
+
+    const revenueByAgent: Record<string, number> = {};
+    for (const c of contracts) {
+      if (c.agentId) {
+        revenueByAgent[c.agentId] = (revenueByAgent[c.agentId] ?? 0) + Number(c.totalAmount);
+      }
+    }
+
+    // Get total leads per agent
+    const totalLeads = await this.prisma.lead.groupBy({
+      by: ['assignedAgentId'],
+      where: { assignedAgentId: { not: null } },
+      _count: true,
+    });
+
+    // Merge all agent IDs
+    const agentIds = new Set<string>();
+    wonLeads.forEach((w) => w.assignedAgentId && agentIds.add(w.assignedAgentId));
+    Object.keys(revenueByAgent).forEach((id) => agentIds.add(id));
+    totalLeads.forEach((t) => t.assignedAgentId && agentIds.add(t.assignedAgentId));
+
+    const agents = Array.from(agentIds).map((agentId) => ({
+      agentId,
+      leadsWon: wonLeads.find((w) => w.assignedAgentId === agentId)?._count ?? 0,
+      totalLeads: totalLeads.find((t) => t.assignedAgentId === agentId)?._count ?? 0,
+      revenue: revenueByAgent[agentId] ?? 0,
+    }));
+
+    agents.sort((a, b) => b.revenue - a.revenue);
+
+    return { agents, period: { start, end } };
+  }
+
+  async getAdminRecent(limit = 20) {
+    return this.prisma.activity.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+  }
+
+  // ─── Agent Endpoints ────────────────────────────────────────────────
+
+  async getAgentOverview(agentId: string) {
+    const [properties, clients, leads, upcomingFollowUps] = await Promise.all([
+      this.prisma.property.count({ where: { assignedAgentId: agentId } }),
+      this.prisma.client.count({ where: { assignedAgentId: agentId } }),
+      this.prisma.lead.count({ where: { assignedAgentId: agentId } }),
+      this.prisma.lead.count({
+        where: {
+          assignedAgentId: agentId,
+          nextFollowUp: { gte: new Date() },
+          status: { notIn: [LeadStatus.WON, LeadStatus.LOST] },
+        },
+      }),
+    ]);
+
+    return {
+      properties,
+      clients,
+      leads,
+      upcomingFollowUps,
+    };
+  }
+
+  async getAgentLeads(agentId: string) {
+    const byStatus = await this.prisma.lead.groupBy({
+      by: ['status'],
+      where: { assignedAgentId: agentId },
+      _count: true,
+    });
+
+    return {
+      pipeline: byStatus.map((g) => ({ status: g.status, count: g._count })),
+      total: byStatus.reduce((sum, g) => sum + g._count, 0),
+    };
+  }
+
+  async getAgentFollowUps(agentId: string) {
+    const now = new Date();
+    const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+    const [overdue, upcoming] = await Promise.all([
+      this.prisma.lead.findMany({
+        where: {
+          assignedAgentId: agentId,
+          nextFollowUp: { lt: now },
+          status: { notIn: [LeadStatus.WON, LeadStatus.LOST] },
+        },
+        orderBy: { nextFollowUp: 'asc' },
+        select: {
+          id: true,
+          status: true,
+          priority: true,
+          nextFollowUp: true,
+          client: { select: { id: true, firstName: true, lastName: true, phone: true } },
+          property: { select: { id: true, title: true } },
+        },
+      }),
+      this.prisma.lead.findMany({
+        where: {
+          assignedAgentId: agentId,
+          nextFollowUp: { gte: now, lte: nextWeek },
+          status: { notIn: [LeadStatus.WON, LeadStatus.LOST] },
+        },
+        orderBy: { nextFollowUp: 'asc' },
+        select: {
+          id: true,
+          status: true,
+          priority: true,
+          nextFollowUp: true,
+          client: { select: { id: true, firstName: true, lastName: true, phone: true } },
+          property: { select: { id: true, title: true } },
+        },
+      }),
+    ]);
+
+    return { overdue, upcoming };
+  }
+
+  async getAgentPerformance(agentId: string) {
+    const now = new Date();
+    const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const lastMonthEnd = new Date(thisMonthStart.getTime() - 1);
+
+    const [
+      thisMonthLeads,
+      lastMonthLeads,
+      thisMonthWon,
+      lastMonthWon,
+      thisMonthRevenue,
+      lastMonthRevenue,
+    ] = await Promise.all([
+      this.prisma.lead.count({
+        where: { assignedAgentId: agentId, createdAt: { gte: thisMonthStart } },
+      }),
+      this.prisma.lead.count({
+        where: { assignedAgentId: agentId, createdAt: { gte: lastMonthStart, lte: lastMonthEnd } },
+      }),
+      this.prisma.lead.count({
+        where: { assignedAgentId: agentId, status: LeadStatus.WON, updatedAt: { gte: thisMonthStart } },
+      }),
+      this.prisma.lead.count({
+        where: { assignedAgentId: agentId, status: LeadStatus.WON, updatedAt: { gte: lastMonthStart, lte: lastMonthEnd } },
+      }),
+      this.prisma.contract.aggregate({
+        _sum: { totalAmount: true },
+        where: {
+          agentId,
+          status: { in: [ContractStatus.ACTIVE, ContractStatus.COMPLETED] },
+          createdAt: { gte: thisMonthStart },
+        },
+      }),
+      this.prisma.contract.aggregate({
+        _sum: { totalAmount: true },
+        where: {
+          agentId,
+          status: { in: [ContractStatus.ACTIVE, ContractStatus.COMPLETED] },
+          createdAt: { gte: lastMonthStart, lte: lastMonthEnd },
+        },
+      }),
+    ]);
+
+    const thisRev = Number(thisMonthRevenue._sum.totalAmount ?? 0);
+    const lastRev = Number(lastMonthRevenue._sum.totalAmount ?? 0);
+
+    return {
+      thisMonth: {
+        leads: thisMonthLeads,
+        won: thisMonthWon,
+        revenue: thisRev,
+      },
+      lastMonth: {
+        leads: lastMonthLeads,
+        won: lastMonthWon,
+        revenue: lastRev,
+      },
+      change: {
+        leads: this.percentChange(lastMonthLeads, thisMonthLeads),
+        won: this.percentChange(lastMonthWon, thisMonthWon),
+        revenue: this.percentChange(lastRev, thisRev),
+      },
+    };
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────────────
+
+  private percentChange(previous: number, current: number): number | null {
+    if (previous === 0) return null;
+    return Math.round(((current - previous) / previous) * 10000) / 100;
+  }
+
+  private resolveDateRange(dto: DateRangeDto): { start: Date; end: Date } {
+    const now = new Date();
+
+    if (dto.range === DateRangePreset.CUSTOM && dto.from && dto.to) {
+      return { start: dto.from, end: dto.to };
+    }
+
+    switch (dto.range) {
+      case DateRangePreset.TODAY:
+        return {
+          start: new Date(now.getFullYear(), now.getMonth(), now.getDate()),
+          end: now,
+        };
+      case DateRangePreset.THIS_WEEK: {
+        const day = now.getDay();
+        const diff = day === 0 ? 6 : day - 1; // Monday start
+        const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - diff);
+        return { start, end: now };
+      }
+      case DateRangePreset.THIS_MONTH:
+        return {
+          start: new Date(now.getFullYear(), now.getMonth(), 1),
+          end: now,
+        };
+      case DateRangePreset.LAST_MONTH:
+        return {
+          start: new Date(now.getFullYear(), now.getMonth() - 1, 1),
+          end: new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999),
+        };
+      case DateRangePreset.THIS_QUARTER: {
+        const quarter = Math.floor(now.getMonth() / 3);
+        return {
+          start: new Date(now.getFullYear(), quarter * 3, 1),
+          end: now,
+        };
+      }
+      case DateRangePreset.THIS_YEAR:
+        return {
+          start: new Date(now.getFullYear(), 0, 1),
+          end: now,
+        };
+      default:
+        return {
+          start: new Date(now.getFullYear(), now.getMonth(), 1),
+          end: now,
+        };
+    }
+  }
+}

--- a/src/dashboard/dto/date-range.dto.ts
+++ b/src/dashboard/dto/date-range.dto.ts
@@ -1,0 +1,30 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum DateRangePreset {
+  TODAY = 'today',
+  THIS_WEEK = 'this_week',
+  THIS_MONTH = 'this_month',
+  LAST_MONTH = 'last_month',
+  THIS_QUARTER = 'this_quarter',
+  THIS_YEAR = 'this_year',
+  CUSTOM = 'custom',
+}
+
+export class DateRangeDto {
+  @ApiPropertyOptional({ enum: DateRangePreset, default: DateRangePreset.THIS_MONTH })
+  @IsOptional()
+  @IsEnum(DateRangePreset)
+  range?: DateRangePreset = DateRangePreset.THIS_MONTH;
+
+  @ApiPropertyOptional({ description: 'Custom start date (ISO 8601)', type: String })
+  @IsOptional()
+  @Type(() => Date)
+  from?: Date;
+
+  @ApiPropertyOptional({ description: 'Custom end date (ISO 8601)', type: String })
+  @IsOptional()
+  @Type(() => Date)
+  to?: Date;
+}


### PR DESCRIPTION
## Summary
- Implements **Dashboard module** with admin and agent analytics endpoints (Issue #13)
- **Admin dashboard**: overview totals, revenue timeline with period comparison, lead pipeline summary, property breakdown by status/type, agent performance ranking, recent activities feed
- **Agent dashboard**: personal overview (properties/clients/leads/follow-ups), lead pipeline, overdue & upcoming follow-ups, month-over-month performance comparison
- Date range filtering with presets (today, this_week, this_month, last_month, this_quarter, this_year, custom) and previous-period percentage change calculations

## Endpoints
| Method | Path | Role |
|--------|------|------|
| GET | `/api/dashboard/admin/overview` | admin, manager |
| GET | `/api/dashboard/admin/revenue` | admin, manager |
| GET | `/api/dashboard/admin/leads` | admin, manager |
| GET | `/api/dashboard/admin/properties` | admin, manager |
| GET | `/api/dashboard/admin/agents` | admin, manager |
| GET | `/api/dashboard/admin/recent` | admin, manager |
| GET | `/api/dashboard/agent/overview` | admin, manager, agent |
| GET | `/api/dashboard/agent/leads` | admin, manager, agent |
| GET | `/api/dashboard/agent/follow-ups` | admin, manager, agent |
| GET | `/api/dashboard/agent/performance` | admin, manager, agent |

## Test plan
- [x] TypeScript compiles with no errors
- [x] 19 unit tests passing (controller + service specs)
- [ ] Manual testing with seeded database

🤖 Generated with [Claude Code](https://claude.com/claude-code)