### PR TITLE
feat(admin): Properties Management Pages (#16)

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -8,7 +8,9 @@ import { ErrorBoundary } from './components/ui/ErrorBoundary'
 
 import LoginPage from './pages/LoginPage'
 import DashboardPage from './pages/DashboardPage'
-import PropertiesPage from './pages/PropertiesPage'
+import PropertiesListPage from './pages/properties/PropertiesListPage'
+import PropertyDetailPage from './pages/properties/PropertyDetailPage'
+import PropertyFormPage from './pages/properties/PropertyFormPage'
 import ClientsPage from './pages/ClientsPage'
 import LeadsPage from './pages/LeadsPage'
 import ContractsPage from './pages/ContractsPage'
@@ -37,7 +39,10 @@ export default function App() {
                 }
               >
                 <Route index element={<DashboardPage />} />
-                <Route path="properties" element={<PropertiesPage />} />
+                <Route path="properties" element={<PropertiesListPage />} />
+                <Route path="properties/new" element={<PropertyFormPage />} />
+                <Route path="properties/:id" element={<PropertyDetailPage />} />
+                <Route path="properties/:id/edit" element={<PropertyFormPage />} />
                 <Route path="clients" element={<ClientsPage />} />
                 <Route path="leads" element={<LeadsPage />} />
                 <Route path="contracts" element={<ContractsPage />} />

--- a/admin-ui/src/api/properties.ts
+++ b/admin-ui/src/api/properties.ts
@@ -1,0 +1,55 @@
+import apiClient from './client'
+import type {
+  Property,
+  PropertyFilterParams,
+  PropertyListResponse,
+  CreatePropertyPayload,
+  UpdatePropertyPayload,
+  PropertyStatus,
+} from '../types/property'
+
+const BASE = '/api/properties'
+
+export const propertiesApi = {
+  list(params?: PropertyFilterParams) {
+    return apiClient
+      .get<PropertyListResponse>(BASE, { params })
+      .then((r) => r.data)
+  },
+
+  search(q: string, cursor?: string, take = 20) {
+    return apiClient
+      .get<{ data: Property[]; nextCursor: string | null }>(`${BASE}/search`, {
+        params: { q, cursor, take },
+      })
+      .then((r) => r.data)
+  },
+
+  get(id: string) {
+    return apiClient.get<Property>(`${BASE}/${id}`).then((r) => r.data)
+  },
+
+  create(payload: CreatePropertyPayload) {
+    return apiClient.post<Property>(BASE, payload).then((r) => r.data)
+  },
+
+  update(id: string, payload: UpdatePropertyPayload) {
+    return apiClient.put<Property>(`${BASE}/${id}`, payload).then((r) => r.data)
+  },
+
+  delete(id: string) {
+    return apiClient.delete(`${BASE}/${id}`).then((r) => r.data)
+  },
+
+  changeStatus(id: string, status: PropertyStatus) {
+    return apiClient
+      .patch<Property>(`${BASE}/${id}/status`, { status })
+      .then((r) => r.data)
+  },
+
+  assignAgent(id: string, agentId: string) {
+    return apiClient
+      .patch<Property>(`${BASE}/${id}/assign`, { agentId })
+      .then((r) => r.data)
+  },
+}

--- a/admin-ui/src/components/properties/PropertyCard.tsx
+++ b/admin-ui/src/components/properties/PropertyCard.tsx
@@ -1,0 +1,88 @@
+import { useNavigate } from 'react-router-dom'
+import { MapPin, BedDouble, Bath, Maximize2 } from 'lucide-react'
+import { cn, formatCurrency } from '../../utils'
+import { PROPERTY_STATUSES } from '../../types/property'
+import type { Property } from '../../types/property'
+
+interface PropertyCardProps {
+  property: Property
+}
+
+export function PropertyCard({ property }: PropertyCardProps) {
+  const navigate = useNavigate()
+  const statusMeta = PROPERTY_STATUSES.find((s) => s.value === property.status)
+  const primaryImage = property.images?.find((img) => img.isPrimary) ?? property.images?.[0]
+
+  return (
+    <div
+      onClick={() => navigate(`/properties/${property.id}`)}
+      className={cn(
+        'group cursor-pointer overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm',
+        'transition-all duration-200 hover:shadow-md hover:border-indigo-300',
+        'dark:border-gray-700 dark:bg-gray-800 dark:hover:border-indigo-600',
+      )}
+    >
+      {/* Image */}
+      <div className="relative h-44 overflow-hidden bg-gray-100 dark:bg-gray-700">
+        {primaryImage ? (
+          <img
+            src={primaryImage.url}
+            alt={property.title}
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-gray-400 dark:text-gray-500">
+            <Maximize2 size={32} />
+          </div>
+        )}
+        {statusMeta && (
+          <span
+            className={cn(
+              'absolute right-2 top-2 rounded-full px-2.5 py-0.5 text-xs font-semibold',
+              statusMeta.color,
+            )}
+          >
+            {statusMeta.label}
+          </span>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="p-4">
+        <p className="text-lg font-bold text-indigo-600 dark:text-indigo-400">
+          {formatCurrency(Number(property.price))}
+        </p>
+        <h3 className="mt-1 text-sm font-semibold text-gray-900 line-clamp-1 dark:text-gray-100">
+          {property.title}
+        </h3>
+
+        <div className="mt-2 flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+          <MapPin size={12} />
+          <span className="line-clamp-1">
+            {property.region}, {property.city}
+          </span>
+        </div>
+
+        <div className="mt-3 flex items-center gap-4 text-xs text-gray-600 dark:text-gray-400">
+          {property.bedrooms != null && (
+            <span className="flex items-center gap-1">
+              <BedDouble size={14} /> {property.bedrooms} bd
+            </span>
+          )}
+          {property.bathrooms != null && (
+            <span className="flex items-center gap-1">
+              <Bath size={14} /> {property.bathrooms} ba
+            </span>
+          )}
+          <span className="flex items-center gap-1">
+            <Maximize2 size={14} /> {Number(property.area).toLocaleString()} m²
+          </span>
+        </div>
+
+        <p className="mt-2 rounded bg-gray-50 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:bg-gray-700/50 dark:text-gray-400 w-fit">
+          {property.type.replace('_', ' ')}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/components/properties/PropertyFilters.tsx
+++ b/admin-ui/src/components/properties/PropertyFilters.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react'
+import { Filter, X, RotateCcw } from 'lucide-react'
+import { Button, Input, Select } from '../ui'
+import { PROPERTY_TYPES, PROPERTY_STATUSES } from '../../types/property'
+import type { PropertyFilterParams } from '../../types/property'
+import { cn } from '../../utils'
+
+interface PropertyFiltersProps {
+  filters: PropertyFilterParams
+  onChange: (filters: PropertyFilterParams) => void
+  className?: string
+}
+
+export function PropertyFilters({ filters, onChange, className }: PropertyFiltersProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const activeCount = [
+    filters.type,
+    filters.status,
+    filters.city,
+    filters.minPrice,
+    filters.maxPrice,
+    filters.bedrooms,
+  ].filter(Boolean).length
+
+  function handleReset() {
+    onChange({
+      page: 1,
+      pageSize: filters.pageSize,
+      sortBy: filters.sortBy,
+      sortOrder: filters.sortOrder,
+    })
+  }
+
+  function update(patch: Partial<PropertyFilterParams>) {
+    onChange({ ...filters, page: 1, ...patch })
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      {/* Toggle button for mobile / collapsed */}
+      <div className="flex items-center gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          leftIcon={<Filter size={14} />}
+          onClick={() => setIsOpen((o) => !o)}
+        >
+          Filters
+          {activeCount > 0 && (
+            <span className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-indigo-600 text-[10px] font-bold text-white">
+              {activeCount}
+            </span>
+          )}
+        </Button>
+        {activeCount > 0 && (
+          <Button variant="ghost" size="sm" leftIcon={<RotateCcw size={14} />} onClick={handleReset}>
+            Clear all
+          </Button>
+        )}
+      </div>
+
+      {/* Filter panel */}
+      {isOpen && (
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Filter Properties</h3>
+            <button onClick={() => setIsOpen(false)} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+              <X size={16} />
+            </button>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <Select
+              label="Property Type"
+              placeholder="All types"
+              value={filters.type ?? ''}
+              onChange={(e) => update({ type: (e.target.value || undefined) as PropertyFilterParams['type'] })}
+              options={PROPERTY_TYPES}
+            />
+
+            <Select
+              label="Status"
+              placeholder="All statuses"
+              value={filters.status ?? ''}
+              onChange={(e) => update({ status: (e.target.value || undefined) as PropertyFilterParams['status'] })}
+              options={PROPERTY_STATUSES.map((s) => ({ value: s.value, label: s.label }))}
+            />
+
+            <Input
+              label="City"
+              placeholder="e.g. Cairo"
+              value={filters.city ?? ''}
+              onChange={(e) => update({ city: e.target.value || undefined })}
+            />
+
+            <Input
+              label="Min Bedrooms"
+              type="number"
+              min={0}
+              placeholder="Any"
+              value={filters.bedrooms ?? ''}
+              onChange={(e) => update({ bedrooms: e.target.value ? Number(e.target.value) : undefined })}
+            />
+
+            <Input
+              label="Min Price"
+              type="number"
+              min={0}
+              placeholder="0"
+              value={filters.minPrice ?? ''}
+              onChange={(e) => update({ minPrice: e.target.value || undefined })}
+            />
+
+            <Input
+              label="Max Price"
+              type="number"
+              min={0}
+              placeholder="No limit"
+              value={filters.maxPrice ?? ''}
+              onChange={(e) => update({ maxPrice: e.target.value || undefined })}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/admin-ui/src/pages/properties/PropertiesListPage.tsx
+++ b/admin-ui/src/pages/properties/PropertiesListPage.tsx
@@ -1,0 +1,217 @@
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { Building2, Plus, LayoutGrid, List } from 'lucide-react'
+import { propertiesApi } from '../../api/properties'
+import { Button, DataTable, SearchBar, LoadingSpinner } from '../../components/ui'
+import { PropertyFilters } from '../../components/properties/PropertyFilters'
+import { PropertyCard } from '../../components/properties/PropertyCard'
+import { PROPERTY_STATUSES } from '../../types/property'
+import { formatCurrency } from '../../utils'
+import { cn } from '../../utils'
+import type { PropertyFilterParams, Property } from '../../types/property'
+import type { Column } from '../../types'
+
+type ViewMode = 'table' | 'grid'
+
+export default function PropertiesListPage() {
+  const navigate = useNavigate()
+  const [viewMode, setViewMode] = useState<ViewMode>('table')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [filters, setFilters] = useState<PropertyFilterParams>({
+    page: 1,
+    pageSize: 10,
+    sortBy: 'createdAt',
+    sortOrder: 'desc',
+  })
+
+  const listQuery = useQuery({
+    queryKey: ['properties', filters],
+    queryFn: () => propertiesApi.list(filters),
+    placeholderData: (prev) => prev,
+  })
+
+  const searchQueryResult = useQuery({
+    queryKey: ['properties-search', searchQuery],
+    queryFn: () => propertiesApi.search(searchQuery),
+    enabled: searchQuery.length >= 2,
+  })
+
+  const isSearching = searchQuery.length >= 2
+  const data = isSearching ? searchQueryResult.data?.data : listQuery.data?.data
+  const total = isSearching ? (searchQueryResult.data?.data?.length ?? 0) : (listQuery.data?.total ?? 0)
+  const isLoading = isSearching ? searchQueryResult.isLoading : listQuery.isLoading
+
+  const handleSearch = useCallback((q: string) => {
+    setSearchQuery(q)
+  }, [])
+
+  const columns: Column<Property & Record<string, unknown>>[] = [
+    {
+      key: 'title',
+      header: 'Title',
+      sortable: true,
+      render: (_val, row) => (
+        <div className="max-w-[220px]">
+          <p className="font-medium text-gray-900 dark:text-gray-100 truncate">{row.title as string}</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+            {row.region as string}, {row.city as string}
+          </p>
+        </div>
+      ),
+    },
+    {
+      key: 'type',
+      header: 'Type',
+      sortable: true,
+      render: (val) => (
+        <span className="rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+          {String(val).replace('_', ' ')}
+        </span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      sortable: true,
+      render: (val) => {
+        const meta = PROPERTY_STATUSES.find((s) => s.value === val)
+        return (
+          <span className={cn('rounded-full px-2.5 py-0.5 text-xs font-semibold', meta?.color)}>
+            {meta?.label ?? String(val)}
+          </span>
+        )
+      },
+    },
+    {
+      key: 'price',
+      header: 'Price',
+      sortable: true,
+      render: (val) => (
+        <span className="font-semibold text-indigo-600 dark:text-indigo-400">
+          {formatCurrency(Number(val))}
+        </span>
+      ),
+    },
+    {
+      key: 'area',
+      header: 'Area',
+      sortable: true,
+      render: (val) => `${Number(val).toLocaleString()} m²`,
+    },
+    {
+      key: 'bedrooms',
+      header: 'Beds',
+      render: (val) => (val != null ? String(val) : '-'),
+    },
+    {
+      key: 'assignedAgent',
+      header: 'Agent',
+      render: (_val, row) => {
+        const agent = row.assignedAgent as Property['assignedAgent']
+        return agent ? (
+          <span className="text-sm">{agent.name}</span>
+        ) : (
+          <span className="text-gray-400 text-xs">Unassigned</span>
+        )
+      },
+    },
+    {
+      key: 'createdAt',
+      header: 'Created',
+      sortable: true,
+      render: (val) => new Date(String(val)).toLocaleDateString(),
+    },
+  ]
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Building2 size={24} className="text-indigo-500" />
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Properties</h1>
+          {!isLoading && (
+            <span className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              {total}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {/* View toggle */}
+          <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden">
+            <button
+              onClick={() => setViewMode('table')}
+              className={cn(
+                'p-2 transition-colors',
+                viewMode === 'table'
+                  ? 'bg-indigo-600 text-white'
+                  : 'bg-white text-gray-500 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-400',
+              )}
+              title="Table view"
+            >
+              <List size={16} />
+            </button>
+            <button
+              onClick={() => setViewMode('grid')}
+              className={cn(
+                'p-2 transition-colors',
+                viewMode === 'grid'
+                  ? 'bg-indigo-600 text-white'
+                  : 'bg-white text-gray-500 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-400',
+              )}
+              title="Grid view"
+            >
+              <LayoutGrid size={16} />
+            </button>
+          </div>
+          <Button leftIcon={<Plus size={16} />} onClick={() => navigate('/properties/new')}>
+            Add Property
+          </Button>
+        </div>
+      </div>
+
+      {/* Search + Filters */}
+      <div className="flex flex-col gap-3">
+        <SearchBar
+          onSearch={handleSearch}
+          placeholder="Search properties by title, address, city..."
+          className="max-w-md"
+        />
+        {!isSearching && <PropertyFilters filters={filters} onChange={setFilters} />}
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <LoadingSpinner message="Loading properties..." />
+      ) : viewMode === 'table' ? (
+        <DataTable
+          columns={columns}
+          data={(data ?? []) as (Property & Record<string, unknown>)[]}
+          loading={isLoading}
+          page={filters.page ?? 1}
+          pageSize={filters.pageSize ?? 10}
+          total={total}
+          onRowClick={(row) => navigate(`/properties/${row.id}`)}
+          onPageChange={(p) => setFilters((f) => ({ ...f, page: p }))}
+          onPageSizeChange={(ps) => setFilters((f) => ({ ...f, page: 1, pageSize: ps }))}
+          emptyMessage="No properties found. Try adjusting your filters."
+        />
+      ) : (
+        <>
+          {(data?.length ?? 0) === 0 ? (
+            <p className="py-12 text-center text-gray-400 dark:text-gray-500">
+              No properties found. Try adjusting your filters.
+            </p>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {data?.map((property) => (
+                <PropertyCard key={property.id} property={property} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/admin-ui/src/pages/properties/PropertyDetailPage.tsx
+++ b/admin-ui/src/pages/properties/PropertyDetailPage.tsx
@@ -1,0 +1,355 @@
+import { useState } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import {
+  ArrowLeft,
+  Edit,
+  Trash2,
+  MapPin,
+  BedDouble,
+  Bath,
+  Layers,
+  Maximize2,
+  User,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react'
+import { propertiesApi } from '../../api/properties'
+import { Button, LoadingSpinner, Select, ConfirmDialog } from '../../components/ui'
+import { PROPERTY_STATUSES } from '../../types/property'
+import { formatCurrency, cn } from '../../utils'
+import type { PropertyStatus } from '../../types/property'
+
+export default function PropertyDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [showDelete, setShowDelete] = useState(false)
+  const [activeImage, setActiveImage] = useState(0)
+
+  const { data: property, isLoading, error } = useQuery({
+    queryKey: ['property', id],
+    queryFn: () => propertiesApi.get(id!),
+    enabled: !!id,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => propertiesApi.delete(id!),
+    onSuccess: () => {
+      toast.success('Property deleted')
+      queryClient.invalidateQueries({ queryKey: ['properties'] })
+      navigate('/properties')
+    },
+    onError: () => toast.error('Failed to delete property'),
+  })
+
+  const statusMutation = useMutation({
+    mutationFn: (status: PropertyStatus) => propertiesApi.changeStatus(id!, status),
+    onSuccess: () => {
+      toast.success('Status updated')
+      queryClient.invalidateQueries({ queryKey: ['property', id] })
+      queryClient.invalidateQueries({ queryKey: ['properties'] })
+    },
+    onError: () => toast.error('Failed to update status'),
+  })
+
+  if (isLoading) return <LoadingSpinner message="Loading property..." />
+  if (error || !property) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-20 text-gray-500 dark:text-gray-400">
+        <p>Property not found.</p>
+        <Button variant="secondary" onClick={() => navigate('/properties')}>
+          Back to Properties
+        </Button>
+      </div>
+    )
+  }
+
+  const statusMeta = PROPERTY_STATUSES.find((s) => s.value === property.status)
+  const images = property.images?.sort((a, b) => a.order - b.order) ?? []
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Breadcrumb + actions */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <button
+          onClick={() => navigate('/properties')}
+          className="flex items-center gap-1 text-sm text-gray-500 hover:text-indigo-600 dark:text-gray-400 dark:hover:text-indigo-400 transition-colors"
+        >
+          <ArrowLeft size={16} /> Back to Properties
+        </button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            leftIcon={<Edit size={14} />}
+            onClick={() => navigate(`/properties/${id}/edit`)}
+          >
+            Edit
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
+            leftIcon={<Trash2 size={14} />}
+            onClick={() => setShowDelete(true)}
+          >
+            Delete
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Main column */}
+        <div className="lg:col-span-2 flex flex-col gap-6">
+          {/* Image gallery */}
+          {images.length > 0 && (
+            <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800">
+              <div className="relative h-80">
+                <img
+                  src={images[activeImage]?.url}
+                  alt={images[activeImage]?.caption ?? property.title}
+                  className="h-full w-full object-cover"
+                />
+                {images.length > 1 && (
+                  <>
+                    <button
+                      onClick={() => setActiveImage((i) => (i === 0 ? images.length - 1 : i - 1))}
+                      className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-1.5 text-white hover:bg-black/60 transition-colors"
+                    >
+                      <ChevronLeft size={20} />
+                    </button>
+                    <button
+                      onClick={() => setActiveImage((i) => (i === images.length - 1 ? 0 : i + 1))}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-1.5 text-white hover:bg-black/60 transition-colors"
+                    >
+                      <ChevronRight size={20} />
+                    </button>
+                  </>
+                )}
+                <span className="absolute bottom-2 right-2 rounded-full bg-black/50 px-2.5 py-0.5 text-xs text-white">
+                  {activeImage + 1} / {images.length}
+                </span>
+              </div>
+              {images.length > 1 && (
+                <div className="flex gap-1 overflow-x-auto p-2">
+                  {images.map((img, idx) => (
+                    <button
+                      key={img.id}
+                      onClick={() => setActiveImage(idx)}
+                      className={cn(
+                        'h-16 w-20 flex-shrink-0 overflow-hidden rounded-md border-2 transition-all',
+                        idx === activeImage
+                          ? 'border-indigo-500 opacity-100'
+                          : 'border-transparent opacity-60 hover:opacity-100',
+                      )}
+                    >
+                      <img src={img.url} alt={img.caption ?? ''} className="h-full w-full object-cover" />
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Title + details */}
+          <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{property.title}</h1>
+                <div className="mt-1 flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400">
+                  <MapPin size={14} />
+                  {property.address}, {property.region}, {property.city}
+                </div>
+              </div>
+              <p className="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
+                {formatCurrency(Number(property.price))}
+              </p>
+            </div>
+
+            {/* Quick stats */}
+            <div className="mt-5 grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <InfoItem icon={<Maximize2 size={16} />} label="Area" value={`${Number(property.area).toLocaleString()} m²`} />
+              {property.bedrooms != null && (
+                <InfoItem icon={<BedDouble size={16} />} label="Bedrooms" value={String(property.bedrooms)} />
+              )}
+              {property.bathrooms != null && (
+                <InfoItem icon={<Bath size={16} />} label="Bathrooms" value={String(property.bathrooms)} />
+              )}
+              {property.floor != null && (
+                <InfoItem icon={<Layers size={16} />} label="Floor" value={String(property.floor)} />
+              )}
+            </div>
+
+            {property.description && (
+              <div className="mt-5 border-t border-gray-100 pt-5 dark:border-gray-700">
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Description</h3>
+                <p className="mt-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
+                  {property.description}
+                </p>
+              </div>
+            )}
+
+            {property.features && property.features.length > 0 && (
+              <div className="mt-5 border-t border-gray-100 pt-5 dark:border-gray-700">
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Features</h3>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {property.features.map((f) => (
+                    <span
+                      key={f}
+                      className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300"
+                    >
+                      {f}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Related leads */}
+          {property.leads && property.leads.length > 0 && (
+            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Related Leads</h3>
+              <div className="mt-3 divide-y divide-gray-100 dark:divide-gray-700">
+                {property.leads.map((lead) => (
+                  <div key={lead.id} className="flex items-center justify-between py-2.5 text-sm">
+                    <span className="text-gray-800 dark:text-gray-200">{lead.title}</span>
+                    <div className="flex items-center gap-3">
+                      <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-400">
+                        {lead.status}
+                      </span>
+                      <span className="text-xs text-gray-400">
+                        {new Date(lead.createdAt).toLocaleDateString()}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Related contracts */}
+          {property.contracts && property.contracts.length > 0 && (
+            <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Contracts</h3>
+              <div className="mt-3 divide-y divide-gray-100 dark:divide-gray-700">
+                {property.contracts.map((contract) => (
+                  <div key={contract.id} className="flex items-center justify-between py-2.5 text-sm">
+                    <div>
+                      <span className="text-gray-800 dark:text-gray-200">{contract.type}</span>
+                      <span className="ml-2 text-xs text-gray-400">{contract.status}</span>
+                    </div>
+                    <span className="font-medium text-gray-700 dark:text-gray-300">
+                      {formatCurrency(Number(contract.totalAmount))}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <div className="flex flex-col gap-4">
+          {/* Status card */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Status</h3>
+            <span className={cn('inline-block rounded-full px-3 py-1 text-xs font-semibold', statusMeta?.color)}>
+              {statusMeta?.label ?? property.status}
+            </span>
+            <div className="mt-4">
+              <Select
+                label="Change Status"
+                value={property.status}
+                onChange={(e) => statusMutation.mutate(e.target.value as PropertyStatus)}
+                options={PROPERTY_STATUSES.map((s) => ({ value: s.value, label: s.label }))}
+              />
+            </div>
+          </div>
+
+          {/* Type */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">Type</h3>
+            <p className="text-sm text-gray-800 dark:text-gray-200">{property.type.replace('_', ' ')}</p>
+          </div>
+
+          {/* Agent */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Assigned Agent</h3>
+            {property.assignedAgent ? (
+              <div className="flex items-center gap-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-full bg-indigo-100 dark:bg-indigo-900/30">
+                  <User size={16} className="text-indigo-600 dark:text-indigo-400" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                    {property.assignedAgent.name}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{property.assignedAgent.email}</p>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400">No agent assigned</p>
+            )}
+          </div>
+
+          {/* Metadata */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Details</h3>
+            <dl className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <dt className="text-gray-500 dark:text-gray-400">ID</dt>
+                <dd className="font-mono text-xs text-gray-700 dark:text-gray-300 truncate max-w-[180px]">
+                  {property.id}
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-gray-500 dark:text-gray-400">Created</dt>
+                <dd className="text-gray-700 dark:text-gray-300">
+                  {new Date(property.createdAt).toLocaleDateString()}
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-gray-500 dark:text-gray-400">Updated</dt>
+                <dd className="text-gray-700 dark:text-gray-300">
+                  {new Date(property.updatedAt).toLocaleDateString()}
+                </dd>
+              </div>
+              {property.latitude && property.longitude && (
+                <div className="flex justify-between">
+                  <dt className="text-gray-500 dark:text-gray-400">Coordinates</dt>
+                  <dd className="text-gray-700 dark:text-gray-300 text-xs">
+                    {property.latitude}, {property.longitude}
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        isOpen={showDelete}
+        title="Delete Property"
+        message={`Are you sure you want to delete "${property.title}"? This will set the property to OFF_MARKET status.`}
+        confirmLabel="Delete"
+        onConfirm={() => deleteMutation.mutate()}
+        onCancel={() => setShowDelete(false)}
+        loading={deleteMutation.isPending}
+      />
+    </div>
+  )
+}
+
+function InfoItem({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2.5 dark:bg-gray-700/40">
+      <span className="text-indigo-500 dark:text-indigo-400">{icon}</span>
+      <div>
+        <p className="text-[11px] text-gray-500 dark:text-gray-400">{label}</p>
+        <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">{value}</p>
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/properties/PropertyFormPage.tsx
+++ b/admin-ui/src/pages/properties/PropertyFormPage.tsx
@@ -1,0 +1,357 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import { ArrowLeft, Save, Plus, X } from 'lucide-react'
+import { propertiesApi } from '../../api/properties'
+import { Button, Input, Select, Textarea, LoadingSpinner } from '../../components/ui'
+import { PROPERTY_TYPES } from '../../types/property'
+import type { CreatePropertyPayload } from '../../types/property'
+
+const EMPTY_FORM: CreatePropertyPayload = {
+  title: '',
+  description: '',
+  type: 'APARTMENT',
+  price: '',
+  area: '',
+  bedrooms: undefined,
+  bathrooms: undefined,
+  floor: undefined,
+  address: '',
+  city: '',
+  region: '',
+  latitude: '',
+  longitude: '',
+  features: [],
+}
+
+export default function PropertyFormPage() {
+  const { id } = useParams<{ id: string }>()
+  const isEdit = Boolean(id)
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const [form, setForm] = useState<CreatePropertyPayload>(EMPTY_FORM)
+  const [featureInput, setFeatureInput] = useState('')
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  // Load existing property for edit
+  const { data: existing, isLoading: loadingExisting } = useQuery({
+    queryKey: ['property', id],
+    queryFn: () => propertiesApi.get(id!),
+    enabled: isEdit,
+  })
+
+  useEffect(() => {
+    if (existing) {
+      setForm({
+        title: existing.title,
+        description: existing.description ?? '',
+        type: existing.type,
+        price: existing.price,
+        area: existing.area,
+        bedrooms: existing.bedrooms ?? undefined,
+        bathrooms: existing.bathrooms ?? undefined,
+        floor: existing.floor ?? undefined,
+        address: existing.address,
+        city: existing.city,
+        region: existing.region,
+        latitude: existing.latitude ?? '',
+        longitude: existing.longitude ?? '',
+        features: existing.features ?? [],
+      })
+    }
+  }, [existing])
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreatePropertyPayload) => propertiesApi.create(data),
+    onSuccess: (created) => {
+      toast.success('Property created successfully')
+      queryClient.invalidateQueries({ queryKey: ['properties'] })
+      navigate(`/properties/${created.id}`)
+    },
+    onError: () => toast.error('Failed to create property'),
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: (data: CreatePropertyPayload) => propertiesApi.update(id!, data),
+    onSuccess: () => {
+      toast.success('Property updated successfully')
+      queryClient.invalidateQueries({ queryKey: ['properties'] })
+      queryClient.invalidateQueries({ queryKey: ['property', id] })
+      navigate(`/properties/${id}`)
+    },
+    onError: () => toast.error('Failed to update property'),
+  })
+
+  const saving = createMutation.isPending || updateMutation.isPending
+
+  function validate(): boolean {
+    const errs: Record<string, string> = {}
+    if (!form.title.trim()) errs.title = 'Title is required'
+    if (!form.price) errs.price = 'Price is required'
+    if (!form.area) errs.area = 'Area is required'
+    if (!form.address.trim()) errs.address = 'Address is required'
+    if (!form.city.trim()) errs.city = 'City is required'
+    if (!form.region.trim()) errs.region = 'Region is required'
+    setErrors(errs)
+    return Object.keys(errs).length === 0
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+
+    // Clean optional fields
+    const payload: CreatePropertyPayload = {
+      ...form,
+      price: form.price,
+      area: form.area,
+      bedrooms: form.bedrooms || undefined,
+      bathrooms: form.bathrooms || undefined,
+      floor: form.floor || undefined,
+      latitude: form.latitude || undefined,
+      longitude: form.longitude || undefined,
+      features: form.features?.length ? form.features : undefined,
+      description: form.description?.trim() || undefined,
+    }
+
+    if (isEdit) {
+      updateMutation.mutate(payload)
+    } else {
+      createMutation.mutate(payload)
+    }
+  }
+
+  function updateField<K extends keyof CreatePropertyPayload>(key: K, value: CreatePropertyPayload[K]) {
+    setForm((f) => ({ ...f, [key]: value }))
+    if (errors[key]) setErrors((e) => ({ ...e, [key]: '' }))
+  }
+
+  function addFeature() {
+    const trimmed = featureInput.trim()
+    if (trimmed && !form.features?.includes(trimmed)) {
+      updateField('features', [...(form.features ?? []), trimmed])
+      setFeatureInput('')
+    }
+  }
+
+  function removeFeature(feature: string) {
+    updateField('features', (form.features ?? []).filter((f) => f !== feature))
+  }
+
+  if (isEdit && loadingExisting) return <LoadingSpinner message="Loading property..." />
+
+  return (
+    <div className="flex flex-col gap-6 max-w-4xl">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => navigate(isEdit ? `/properties/${id}` : '/properties')}
+          className="flex items-center gap-1 text-sm text-gray-500 hover:text-indigo-600 dark:text-gray-400 dark:hover:text-indigo-400 transition-colors"
+        >
+          <ArrowLeft size={16} /> Back
+        </button>
+      </div>
+
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        {isEdit ? 'Edit Property' : 'New Property'}
+      </h1>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+        {/* Basic Info */}
+        <section className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h2 className="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">
+            Basic Information
+          </h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <Input
+                label="Title"
+                required
+                value={form.title}
+                onChange={(e) => updateField('title', e.target.value)}
+                error={errors.title}
+                placeholder="e.g. Luxury 3BR Apartment in Zamalek"
+              />
+            </div>
+
+            <Select
+              label="Property Type"
+              required
+              value={form.type}
+              onChange={(e) => updateField('type', e.target.value as CreatePropertyPayload['type'])}
+              options={PROPERTY_TYPES}
+            />
+
+            <Input
+              label="Price (EGP)"
+              required
+              type="number"
+              min={0}
+              step="0.01"
+              value={form.price}
+              onChange={(e) => updateField('price', e.target.value)}
+              error={errors.price}
+              placeholder="2500000"
+            />
+
+            <Input
+              label="Area (m²)"
+              required
+              type="number"
+              min={0}
+              step="0.01"
+              value={form.area}
+              onChange={(e) => updateField('area', e.target.value)}
+              error={errors.area}
+              placeholder="180"
+            />
+
+            <Input
+              label="Bedrooms"
+              type="number"
+              min={0}
+              value={form.bedrooms ?? ''}
+              onChange={(e) => updateField('bedrooms', e.target.value ? Number(e.target.value) : undefined)}
+              placeholder="3"
+            />
+
+            <Input
+              label="Bathrooms"
+              type="number"
+              min={0}
+              value={form.bathrooms ?? ''}
+              onChange={(e) => updateField('bathrooms', e.target.value ? Number(e.target.value) : undefined)}
+              placeholder="2"
+            />
+
+            <Input
+              label="Floor"
+              type="number"
+              value={form.floor ?? ''}
+              onChange={(e) => updateField('floor', e.target.value ? Number(e.target.value) : undefined)}
+              placeholder="5"
+            />
+
+            <div className="sm:col-span-2">
+              <Textarea
+                label="Description"
+                value={form.description ?? ''}
+                onChange={(e) => updateField('description', e.target.value)}
+                placeholder="Detailed description of the property..."
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* Location */}
+        <section className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h2 className="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">
+            Location
+          </h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <Input
+                label="Address"
+                required
+                value={form.address}
+                onChange={(e) => updateField('address', e.target.value)}
+                error={errors.address}
+                placeholder="15 Abu El Feda St"
+              />
+            </div>
+            <Input
+              label="City"
+              required
+              value={form.city}
+              onChange={(e) => updateField('city', e.target.value)}
+              error={errors.city}
+              placeholder="Cairo"
+            />
+            <Input
+              label="Region / District"
+              required
+              value={form.region}
+              onChange={(e) => updateField('region', e.target.value)}
+              error={errors.region}
+              placeholder="Zamalek"
+            />
+            <Input
+              label="Latitude"
+              type="number"
+              step="0.0000001"
+              value={form.latitude ?? ''}
+              onChange={(e) => updateField('latitude', e.target.value)}
+              placeholder="30.0561000"
+            />
+            <Input
+              label="Longitude"
+              type="number"
+              step="0.0000001"
+              value={form.longitude ?? ''}
+              onChange={(e) => updateField('longitude', e.target.value)}
+              placeholder="31.2243000"
+            />
+          </div>
+        </section>
+
+        {/* Features */}
+        <section className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h2 className="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">
+            Features
+          </h2>
+          <div className="flex gap-2">
+            <Input
+              value={featureInput}
+              onChange={(e) => setFeatureInput(e.target.value)}
+              placeholder="e.g. pool, gym, parking"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  addFeature()
+                }
+              }}
+            />
+            <Button type="button" variant="secondary" onClick={addFeature} leftIcon={<Plus size={14} />}>
+              Add
+            </Button>
+          </div>
+          {form.features && form.features.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {form.features.map((f) => (
+                <span
+                  key={f}
+                  className="inline-flex items-center gap-1 rounded-full bg-indigo-50 pl-3 pr-1.5 py-1 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300"
+                >
+                  {f}
+                  <button
+                    type="button"
+                    onClick={() => removeFeature(f)}
+                    className="rounded-full p-0.5 hover:bg-indigo-200 dark:hover:bg-indigo-800 transition-colors"
+                  >
+                    <X size={12} />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => navigate(isEdit ? `/properties/${id}` : '/properties')}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" loading={saving} leftIcon={<Save size={16} />}>
+            {isEdit ? 'Save Changes' : 'Create Property'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/admin-ui/src/types/property.ts
+++ b/admin-ui/src/types/property.ts
@@ -1,0 +1,140 @@
+// Property enums matching the Prisma schema
+export type PropertyType =
+  | 'APARTMENT'
+  | 'VILLA'
+  | 'OFFICE'
+  | 'SHOP'
+  | 'LAND'
+  | 'BUILDING'
+  | 'CHALET'
+  | 'STUDIO'
+  | 'DUPLEX'
+  | 'PENTHOUSE'
+
+export type PropertyStatus =
+  | 'AVAILABLE'
+  | 'RESERVED'
+  | 'SOLD'
+  | 'RENTED'
+  | 'OFF_MARKET'
+
+export const PROPERTY_TYPES: { value: PropertyType; label: string }[] = [
+  { value: 'APARTMENT', label: 'Apartment' },
+  { value: 'VILLA', label: 'Villa' },
+  { value: 'OFFICE', label: 'Office' },
+  { value: 'SHOP', label: 'Shop' },
+  { value: 'LAND', label: 'Land' },
+  { value: 'BUILDING', label: 'Building' },
+  { value: 'CHALET', label: 'Chalet' },
+  { value: 'STUDIO', label: 'Studio' },
+  { value: 'DUPLEX', label: 'Duplex' },
+  { value: 'PENTHOUSE', label: 'Penthouse' },
+]
+
+export const PROPERTY_STATUSES: { value: PropertyStatus; label: string; color: string }[] = [
+  { value: 'AVAILABLE', label: 'Available', color: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' },
+  { value: 'RESERVED', label: 'Reserved', color: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400' },
+  { value: 'SOLD', label: 'Sold', color: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400' },
+  { value: 'RENTED', label: 'Rented', color: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400' },
+  { value: 'OFF_MARKET', label: 'Off Market', color: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-400' },
+]
+
+export interface PropertyImage {
+  id: string
+  propertyId: string
+  url: string
+  caption: string | null
+  isPrimary: boolean
+  order: number
+  createdAt: string
+}
+
+export interface PropertyAgent {
+  id: string
+  name: string
+  email: string
+}
+
+export interface PropertyLead {
+  id: string
+  title: string
+  status: string
+  priority: string
+  createdAt: string
+}
+
+export interface PropertyContract {
+  id: string
+  type: string
+  status: string
+  totalAmount: string
+  createdAt: string
+}
+
+export interface Property {
+  id: string
+  title: string
+  description: string | null
+  type: PropertyType
+  status: PropertyStatus
+  price: string
+  area: string
+  bedrooms: number | null
+  bathrooms: number | null
+  floor: number | null
+  address: string
+  city: string
+  region: string
+  latitude: string | null
+  longitude: string | null
+  features: string[] | null
+  assignedAgentId: string | null
+  assignedAgent: PropertyAgent | null
+  images: PropertyImage[]
+  leads?: PropertyLead[]
+  contracts?: PropertyContract[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface PropertyFilterParams {
+  page?: number
+  pageSize?: number
+  type?: PropertyType
+  status?: PropertyStatus
+  minPrice?: string
+  maxPrice?: string
+  minArea?: string
+  maxArea?: string
+  city?: string
+  bedrooms?: number
+  sortBy?: 'createdAt' | 'price' | 'area' | 'title'
+  sortOrder?: 'asc' | 'desc'
+}
+
+export interface PropertyListResponse {
+  data: Property[]
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+}
+
+export interface CreatePropertyPayload {
+  title: string
+  description?: string
+  type: PropertyType
+  price: string
+  area: string
+  bedrooms?: number
+  bathrooms?: number
+  floor?: number
+  address: string
+  city: string
+  region: string
+  latitude?: string
+  longitude?: string
+  features?: string[]
+}
+
+export type UpdatePropertyPayload = Partial<CreatePropertyPayload>


### PR DESCRIPTION
## Summary
- **Properties API client** (`api/properties.ts`) — list, get, create, update, delete, status change, assign agent
- **PropertiesListPage** — DataTable with filters (type, status, price range, city, bedrooms), full-text search, pagination, sorting, and a grid/card view toggle
- **PropertyDetailPage** — Full property info, image gallery with navigation, status change dropdown, assigned agent card, related leads & contracts sections, delete confirmation
- **PropertyFormPage** — Create/edit form with three sections (basic info, location, features), client-side validation, tag-style features input
- **PropertyFilters** — Collapsible filter sidebar with active-filter count badge
- **PropertyCard** — Card component for grid view with image, price, location, and stats
- **TypeScript types** (`types/property.ts`) — Interfaces for Property, PropertyImage, filter params, create/update payloads matching the Prisma schema

## Routes added
| Path | Component |
|---|---|
| `/properties` | PropertiesListPage |
| `/properties/new` | PropertyFormPage |
| `/properties/:id` | PropertyDetailPage |
| `/properties/:id/edit` | PropertyFormPage |

## Test plan
- [ ] Navigate to /properties — verify table loads with pagination
- [ ] Toggle grid view — verify cards render
- [ ] Use search bar — verify full-text search triggers after 2+ chars
- [ ] Open filter panel, apply type/status/price filters — verify list updates
- [ ] Click "Add Property" — verify create form renders with validation
- [ ] Submit create form — verify API call and redirect to detail page
- [ ] View property detail — verify image gallery, info, status, agent sections
- [ ] Change status from detail page — verify toast and data refresh
- [ ] Click Edit — verify form pre-fills with existing data
- [ ] Delete property — verify confirmation dialog and redirect

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)