### PR TITLE
feat(admin): Clients & Leads Pages (#17)

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -11,8 +11,13 @@ import DashboardPage from './pages/DashboardPage'
 import PropertiesListPage from './pages/properties/PropertiesListPage'
 import PropertyDetailPage from './pages/properties/PropertyDetailPage'
 import PropertyFormPage from './pages/properties/PropertyFormPage'
-import ClientsPage from './pages/ClientsPage'
-import LeadsPage from './pages/LeadsPage'
+import ClientsListPage from './pages/clients/ClientsListPage'
+import ClientDetailPage from './pages/clients/ClientDetailPage'
+import ClientFormPage from './pages/clients/ClientFormPage'
+import LeadsListPage from './pages/leads/LeadsListPage'
+import LeadsKanbanPage from './pages/leads/LeadsKanbanPage'
+import LeadDetailPage from './pages/leads/LeadDetailPage'
+import LeadFormPage from './pages/leads/LeadFormPage'
 import ContractsPage from './pages/ContractsPage'
 import InvoicesPage from './pages/InvoicesPage'
 import ReportsPage from './pages/ReportsPage'
@@ -43,8 +48,15 @@ export default function App() {
                 <Route path="properties/new" element={<PropertyFormPage />} />
                 <Route path="properties/:id" element={<PropertyDetailPage />} />
                 <Route path="properties/:id/edit" element={<PropertyFormPage />} />
-                <Route path="clients" element={<ClientsPage />} />
-                <Route path="leads" element={<LeadsPage />} />
+                <Route path="clients" element={<ClientsListPage />} />
+                <Route path="clients/new" element={<ClientFormPage />} />
+                <Route path="clients/:id" element={<ClientDetailPage />} />
+                <Route path="clients/:id/edit" element={<ClientFormPage />} />
+                <Route path="leads" element={<LeadsListPage />} />
+                <Route path="leads/kanban" element={<LeadsKanbanPage />} />
+                <Route path="leads/new" element={<LeadFormPage />} />
+                <Route path="leads/:id" element={<LeadDetailPage />} />
+                <Route path="leads/:id/edit" element={<LeadFormPage />} />
                 <Route path="contracts" element={<ContractsPage />} />
                 <Route path="invoices" element={<InvoicesPage />} />
                 <Route path="reports" element={<ReportsPage />} />

--- a/admin-ui/src/api/clients.ts
+++ b/admin-ui/src/api/clients.ts
@@ -1,0 +1,51 @@
+import apiClient from './client'
+import type { PaginatedResponse } from '../types'
+import type {
+  Client,
+  ClientDetail,
+  ClientHistory,
+  ClientFilter,
+  ClientStats,
+  CreateClientPayload,
+  UpdateClientPayload,
+} from '../types/client'
+
+const BASE = '/api/clients'
+
+export const clientsApi = {
+  list(filter?: ClientFilter) {
+    return apiClient
+      .get<PaginatedResponse<Client>>(BASE, { params: filter })
+      .then((r) => r.data)
+  },
+
+  getById(id: string) {
+    return apiClient.get<ClientDetail>(`${BASE}/${id}`).then((r) => r.data)
+  },
+
+  getStats() {
+    return apiClient.get<ClientStats>(`${BASE}/stats`).then((r) => r.data)
+  },
+
+  getHistory(id: string) {
+    return apiClient.get<ClientHistory>(`${BASE}/${id}/history`).then((r) => r.data)
+  },
+
+  create(data: CreateClientPayload) {
+    return apiClient.post<Client>(BASE, data).then((r) => r.data)
+  },
+
+  update(id: string, data: UpdateClientPayload) {
+    return apiClient.put<Client>(`${BASE}/${id}`, data).then((r) => r.data)
+  },
+
+  remove(id: string) {
+    return apiClient.delete(`${BASE}/${id}`).then((r) => r.data)
+  },
+
+  assignAgent(id: string, agentId: string) {
+    return apiClient
+      .patch<Client>(`${BASE}/${id}/assign`, { agentId })
+      .then((r) => r.data)
+  },
+}

--- a/admin-ui/src/api/leads.ts
+++ b/admin-ui/src/api/leads.ts
@@ -1,0 +1,74 @@
+import apiClient from './client'
+import type { PaginatedResponse } from '../types'
+import type {
+  Lead,
+  LeadDetail,
+  LeadActivity,
+  LeadFilter,
+  LeadStats,
+  PipelineData,
+  CreateLeadPayload,
+  UpdateLeadPayload,
+  ChangeStatusPayload,
+  CreateActivityPayload,
+} from '../types/lead'
+
+const BASE = '/api/leads'
+
+export const leadsApi = {
+  list(filter?: LeadFilter) {
+    return apiClient
+      .get<PaginatedResponse<Lead>>(BASE, { params: filter })
+      .then((r) => r.data)
+  },
+
+  getById(id: string) {
+    return apiClient.get<LeadDetail>(`${BASE}/${id}`).then((r) => r.data)
+  },
+
+  getStats() {
+    return apiClient.get<LeadStats>(`${BASE}/stats`).then((r) => r.data)
+  },
+
+  getPipeline() {
+    return apiClient.get<PipelineData>(`${BASE}/pipeline`).then((r) => r.data)
+  },
+
+  create(data: CreateLeadPayload) {
+    return apiClient.post<Lead>(BASE, data).then((r) => r.data)
+  },
+
+  update(id: string, data: UpdateLeadPayload) {
+    return apiClient.put<Lead>(`${BASE}/${id}`, data).then((r) => r.data)
+  },
+
+  remove(id: string) {
+    return apiClient.delete(`${BASE}/${id}`).then((r) => r.data)
+  },
+
+  changeStatus(id: string, data: ChangeStatusPayload) {
+    return apiClient
+      .patch<Lead>(`${BASE}/${id}/status`, data)
+      .then((r) => r.data)
+  },
+
+  assignAgent(id: string, agentId: string) {
+    return apiClient
+      .patch<Lead>(`${BASE}/${id}/assign`, { agentId })
+      .then((r) => r.data)
+  },
+
+  addActivity(id: string, data: CreateActivityPayload) {
+    return apiClient
+      .post<LeadActivity>(`${BASE}/${id}/activities`, data)
+      .then((r) => r.data)
+  },
+
+  getActivities(id: string, page = 1, limit = 20) {
+    return apiClient
+      .get<PaginatedResponse<LeadActivity>>(`${BASE}/${id}/activities`, {
+        params: { page, limit },
+      })
+      .then((r) => r.data)
+  },
+}

--- a/admin-ui/src/hooks/useClients.ts
+++ b/admin-ui/src/hooks/useClients.ts
@@ -1,0 +1,81 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { clientsApi } from '../api/clients'
+import type { ClientFilter, CreateClientPayload, UpdateClientPayload } from '../types/client'
+
+const KEYS = {
+  all: ['clients'] as const,
+  lists: () => [...KEYS.all, 'list'] as const,
+  list: (filter: ClientFilter) => [...KEYS.lists(), filter] as const,
+  details: () => [...KEYS.all, 'detail'] as const,
+  detail: (id: string) => [...KEYS.details(), id] as const,
+  stats: () => [...KEYS.all, 'stats'] as const,
+  history: (id: string) => [...KEYS.all, 'history', id] as const,
+}
+
+export function useClientsList(filter: ClientFilter) {
+  return useQuery({
+    queryKey: KEYS.list(filter),
+    queryFn: () => clientsApi.list(filter),
+    staleTime: 30_000,
+  })
+}
+
+export function useClientDetail(id: string) {
+  return useQuery({
+    queryKey: KEYS.detail(id),
+    queryFn: () => clientsApi.getById(id),
+    enabled: !!id,
+    staleTime: 30_000,
+  })
+}
+
+export function useClientStats() {
+  return useQuery({
+    queryKey: KEYS.stats(),
+    queryFn: () => clientsApi.getStats(),
+    staleTime: 60_000,
+  })
+}
+
+export function useClientHistory(id: string) {
+  return useQuery({
+    queryKey: KEYS.history(id),
+    queryFn: () => clientsApi.getHistory(id),
+    enabled: !!id,
+    staleTime: 30_000,
+  })
+}
+
+export function useCreateClient() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: CreateClientPayload) => clientsApi.create(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.stats() })
+    },
+  })
+}
+
+export function useUpdateClient() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateClientPayload }) =>
+      clientsApi.update(id, data),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.detail(id) })
+    },
+  })
+}
+
+export function useDeleteClient() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => clientsApi.remove(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.stats() })
+    },
+  })
+}

--- a/admin-ui/src/hooks/useLeads.ts
+++ b/admin-ui/src/hooks/useLeads.ts
@@ -1,0 +1,125 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { leadsApi } from '../api/leads'
+import type {
+  LeadFilter,
+  CreateLeadPayload,
+  UpdateLeadPayload,
+  ChangeStatusPayload,
+  CreateActivityPayload,
+} from '../types/lead'
+
+const KEYS = {
+  all: ['leads'] as const,
+  lists: () => [...KEYS.all, 'list'] as const,
+  list: (filter: LeadFilter) => [...KEYS.lists(), filter] as const,
+  details: () => [...KEYS.all, 'detail'] as const,
+  detail: (id: string) => [...KEYS.details(), id] as const,
+  stats: () => [...KEYS.all, 'stats'] as const,
+  pipeline: () => [...KEYS.all, 'pipeline'] as const,
+  activities: (id: string) => [...KEYS.all, 'activities', id] as const,
+}
+
+export function useLeadsList(filter: LeadFilter) {
+  return useQuery({
+    queryKey: KEYS.list(filter),
+    queryFn: () => leadsApi.list(filter),
+    staleTime: 30_000,
+  })
+}
+
+export function useLeadDetail(id: string) {
+  return useQuery({
+    queryKey: KEYS.detail(id),
+    queryFn: () => leadsApi.getById(id),
+    enabled: !!id,
+    staleTime: 30_000,
+  })
+}
+
+export function useLeadStats() {
+  return useQuery({
+    queryKey: KEYS.stats(),
+    queryFn: () => leadsApi.getStats(),
+    staleTime: 60_000,
+  })
+}
+
+export function useLeadPipeline() {
+  return useQuery({
+    queryKey: KEYS.pipeline(),
+    queryFn: () => leadsApi.getPipeline(),
+    staleTime: 15_000,
+  })
+}
+
+export function useLeadActivities(id: string, page = 1, limit = 20) {
+  return useQuery({
+    queryKey: [...KEYS.activities(id), page, limit],
+    queryFn: () => leadsApi.getActivities(id, page, limit),
+    enabled: !!id,
+    staleTime: 15_000,
+  })
+}
+
+export function useCreateLead() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: CreateLeadPayload) => leadsApi.create(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.pipeline() })
+      qc.invalidateQueries({ queryKey: KEYS.stats() })
+    },
+  })
+}
+
+export function useUpdateLead() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateLeadPayload }) =>
+      leadsApi.update(id, data),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.detail(id) })
+      qc.invalidateQueries({ queryKey: KEYS.pipeline() })
+    },
+  })
+}
+
+export function useDeleteLead() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => leadsApi.remove(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.pipeline() })
+      qc.invalidateQueries({ queryKey: KEYS.stats() })
+    },
+  })
+}
+
+export function useChangeLeadStatus() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ChangeStatusPayload }) =>
+      leadsApi.changeStatus(id, data),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.detail(id) })
+      qc.invalidateQueries({ queryKey: KEYS.pipeline() })
+      qc.invalidateQueries({ queryKey: KEYS.stats() })
+    },
+  })
+}
+
+export function useAddLeadActivity() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: CreateActivityPayload }) =>
+      leadsApi.addActivity(id, data),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: KEYS.activities(id) })
+      qc.invalidateQueries({ queryKey: KEYS.detail(id) })
+    },
+  })
+}

--- a/admin-ui/src/pages/clients/ClientDetailPage.tsx
+++ b/admin-ui/src/pages/clients/ClientDetailPage.tsx
@@ -1,0 +1,217 @@
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import {
+  ArrowLeft,
+  Edit,
+  Mail,
+  Phone,
+  User,
+  Calendar,
+  FileText,
+  TrendingUp,
+  Clock,
+} from 'lucide-react'
+import { Button, LoadingSpinner } from '../../components/ui'
+import { useClientDetail, useClientHistory } from '../../hooks/useClients'
+import { formatDate, formatCurrency } from '../../utils'
+import type { LeadStatus } from '../../types/lead'
+
+const statusColor: Record<string, string> = {
+  NEW: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  CONTACTED: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  QUALIFIED: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+  PROPOSAL: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  NEGOTIATION: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  WON: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  LOST: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+}
+
+export default function ClientDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { data: client, isLoading, isError } = useClientDetail(id!)
+  const { data: history } = useClientHistory(id!)
+
+  if (isLoading) return <LoadingSpinner message="Loading client..." />
+  if (isError || !client) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16">
+        <p className="text-gray-500">Client not found.</p>
+        <Button variant="secondary" onClick={() => navigate('/clients')}>
+          Back to Clients
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate('/clients')}
+            className="rounded-lg p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800"
+          >
+            <ArrowLeft size={20} />
+          </button>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              {client.firstName} {client.lastName}
+            </h1>
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              {client.type} &middot; {client.source?.replace('_', ' ')}
+            </span>
+          </div>
+        </div>
+        <Button
+          leftIcon={<Edit size={16} />}
+          onClick={() => navigate(`/clients/${id}/edit`)}
+        >
+          Edit Client
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Info Card */}
+        <div className="lg:col-span-1 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
+            <User size={18} className="text-indigo-500" /> Client Info
+          </h2>
+          <dl className="space-y-3 text-sm">
+            {client.email && (
+              <div className="flex items-center gap-2">
+                <Mail size={14} className="text-gray-400 shrink-0" />
+                <dd className="text-gray-700 dark:text-gray-300">{client.email}</dd>
+              </div>
+            )}
+            <div className="flex items-center gap-2">
+              <Phone size={14} className="text-gray-400 shrink-0" />
+              <dd className="text-gray-700 dark:text-gray-300">{client.phone}</dd>
+            </div>
+            {client.nationalId && (
+              <div className="flex items-center gap-2">
+                <FileText size={14} className="text-gray-400 shrink-0" />
+                <dd className="text-gray-700 dark:text-gray-300">ID: {client.nationalId}</dd>
+              </div>
+            )}
+            <div className="flex items-center gap-2">
+              <Calendar size={14} className="text-gray-400 shrink-0" />
+              <dd className="text-gray-700 dark:text-gray-300">Since {formatDate(client.createdAt)}</dd>
+            </div>
+            {client.assignedAgent && (
+              <div className="flex items-center gap-2">
+                <User size={14} className="text-gray-400 shrink-0" />
+                <dd className="text-gray-700 dark:text-gray-300">Agent: {client.assignedAgent.name}</dd>
+              </div>
+            )}
+            {client.notes && (
+              <div className="pt-2 border-t border-gray-100 dark:border-gray-700">
+                <dt className="text-xs font-medium text-gray-500 mb-1">Notes</dt>
+                <dd className="text-gray-700 dark:text-gray-300 whitespace-pre-line">{client.notes}</dd>
+              </div>
+            )}
+          </dl>
+        </div>
+
+        {/* Leads & Contracts */}
+        <div className="lg:col-span-2 flex flex-col gap-6">
+          {/* Leads */}
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
+              <TrendingUp size={18} className="text-indigo-500" /> Leads ({client.leads?.length ?? 0})
+            </h2>
+            {client.leads && client.leads.length > 0 ? (
+              <div className="space-y-2">
+                {client.leads.map((lead) => (
+                  <Link
+                    key={lead.id}
+                    to={`/leads/${lead.id}`}
+                    className="flex items-center justify-between rounded-lg border border-gray-100 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusColor[lead.status] ?? ''}`}>
+                        {lead.status}
+                      </span>
+                      <span className="text-sm text-gray-700 dark:text-gray-300">
+                        {lead.property?.title ?? 'No property'}
+                      </span>
+                    </div>
+                    <span className="text-xs text-gray-500">{formatDate(lead.createdAt)}</span>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400">No leads yet.</p>
+            )}
+          </div>
+
+          {/* Contracts */}
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
+              <FileText size={18} className="text-indigo-500" /> Contracts ({client.contracts?.length ?? 0})
+            </h2>
+            {client.contracts && client.contracts.length > 0 ? (
+              <div className="space-y-2">
+                {client.contracts.map((contract) => (
+                  <Link
+                    key={contract.id}
+                    to={`/contracts/${contract.id}`}
+                    className="flex items-center justify-between rounded-lg border border-gray-100 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-xs font-medium text-gray-500 uppercase">{contract.type}</span>
+                      <span className="text-sm text-gray-700 dark:text-gray-300">
+                        {contract.property?.title ?? 'N/A'}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {formatCurrency(contract.totalAmount)}
+                      </span>
+                      <span className="text-xs text-gray-500">{contract.status}</span>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400">No contracts yet.</p>
+            )}
+          </div>
+
+          {/* Activity History */}
+          {history && (
+            <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
+                <Clock size={18} className="text-indigo-500" /> Activity History
+              </h2>
+              {[...history.leads, ...history.contracts].length > 0 ? (
+                <div className="relative pl-6 border-l-2 border-gray-200 dark:border-gray-700 space-y-4">
+                  {history.leads.map((lead) => (
+                    <div key={`lead-${lead.id}`} className="relative">
+                      <div className="absolute -left-[1.65rem] top-1 w-3 h-3 rounded-full bg-indigo-500" />
+                      <p className="text-sm text-gray-700 dark:text-gray-300">
+                        Lead created &mdash; {lead.status} priority {lead.priority}
+                      </p>
+                      <p className="text-xs text-gray-500">{formatDate(lead.createdAt)}</p>
+                    </div>
+                  ))}
+                  {history.contracts.map((c) => (
+                    <div key={`contract-${c.id}`} className="relative">
+                      <div className="absolute -left-[1.65rem] top-1 w-3 h-3 rounded-full bg-green-500" />
+                      <p className="text-sm text-gray-700 dark:text-gray-300">
+                        Contract ({c.type}) &mdash; {formatCurrency(c.totalAmount)}
+                      </p>
+                      <p className="text-xs text-gray-500">{formatDate(c.createdAt)}</p>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-400">No activity history.</p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/clients/ClientFormPage.tsx
+++ b/admin-ui/src/pages/clients/ClientFormPage.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeft, Save } from 'lucide-react'
+import { Button, Input, Select, Textarea, LoadingSpinner } from '../../components/ui'
+import { useClientDetail, useCreateClient, useUpdateClient } from '../../hooks/useClients'
+import toast from 'react-hot-toast'
+import type { ClientType, ClientSource, CreateClientPayload } from '../../types/client'
+
+const CLIENT_TYPES: { value: ClientType; label: string }[] = [
+  { value: 'BUYER', label: 'Buyer' },
+  { value: 'SELLER', label: 'Seller' },
+  { value: 'TENANT', label: 'Tenant' },
+  { value: 'LANDLORD', label: 'Landlord' },
+  { value: 'INVESTOR', label: 'Investor' },
+]
+
+const CLIENT_SOURCES: { value: ClientSource; label: string }[] = [
+  { value: 'REFERRAL', label: 'Referral' },
+  { value: 'WEBSITE', label: 'Website' },
+  { value: 'SOCIAL_MEDIA', label: 'Social Media' },
+  { value: 'WALK_IN', label: 'Walk-in' },
+  { value: 'PHONE', label: 'Phone' },
+  { value: 'OTHER', label: 'Other' },
+]
+
+interface FormState {
+  firstName: string
+  lastName: string
+  email: string
+  phone: string
+  nationalId: string
+  type: ClientType
+  source: ClientSource
+  notes: string
+}
+
+const INITIAL: FormState = {
+  firstName: '',
+  lastName: '',
+  email: '',
+  phone: '',
+  nationalId: '',
+  type: 'BUYER',
+  source: 'OTHER',
+  notes: '',
+}
+
+export default function ClientFormPage() {
+  const { id } = useParams<{ id: string }>()
+  const isEdit = !!id
+  const navigate = useNavigate()
+  const [form, setForm] = useState<FormState>(INITIAL)
+  const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({})
+
+  const { data: existing, isLoading: loadingExisting } = useClientDetail(id ?? '')
+  const createMutation = useCreateClient()
+  const updateMutation = useUpdateClient()
+
+  useEffect(() => {
+    if (existing && isEdit) {
+      setForm({
+        firstName: existing.firstName,
+        lastName: existing.lastName,
+        email: existing.email ?? '',
+        phone: existing.phone,
+        nationalId: existing.nationalId ?? '',
+        type: existing.type,
+        source: existing.source,
+        notes: existing.notes ?? '',
+      })
+    }
+  }, [existing, isEdit])
+
+  function set<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => ({ ...f, [key]: value }))
+    setErrors((e) => ({ ...e, [key]: undefined }))
+  }
+
+  function validate(): boolean {
+    const errs: Partial<Record<keyof FormState, string>> = {}
+    if (!form.firstName.trim()) errs.firstName = 'First name is required'
+    if (!form.lastName.trim()) errs.lastName = 'Last name is required'
+    if (!form.phone.trim()) errs.phone = 'Phone is required'
+    else if (!/^\+?[0-9]{10,15}$/.test(form.phone.trim()))
+      errs.phone = 'Enter a valid phone (10-15 digits)'
+    if (form.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email))
+      errs.email = 'Enter a valid email'
+    setErrors(errs)
+    return Object.keys(errs).length === 0
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+
+    const payload: CreateClientPayload = {
+      firstName: form.firstName.trim(),
+      lastName: form.lastName.trim(),
+      phone: form.phone.trim(),
+      type: form.type,
+      source: form.source,
+      ...(form.email ? { email: form.email.trim() } : {}),
+      ...(form.nationalId ? { nationalId: form.nationalId.trim() } : {}),
+      ...(form.notes ? { notes: form.notes.trim() } : {}),
+    }
+
+    try {
+      if (isEdit) {
+        await updateMutation.mutateAsync({ id: id!, data: payload })
+        toast.success('Client updated')
+        navigate(`/clients/${id}`)
+      } else {
+        const created = await createMutation.mutateAsync(payload)
+        toast.success('Client created')
+        navigate(`/clients/${created.id}`)
+      }
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'response' in err
+          ? String((err as { response?: { data?: { message?: string } } }).response?.data?.message ?? 'Something went wrong')
+          : 'Something went wrong'
+      toast.error(message)
+    }
+  }
+
+  if (isEdit && loadingExisting) return <LoadingSpinner message="Loading client..." />
+
+  const isPending = createMutation.isPending || updateMutation.isPending
+
+  return (
+    <div className="flex flex-col gap-6 max-w-2xl">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => navigate(isEdit ? `/clients/${id}` : '/clients')}
+          className="rounded-lg p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800"
+        >
+          <ArrowLeft size={20} />
+        </button>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          {isEdit ? 'Edit Client' : 'New Client'}
+        </h1>
+      </div>
+
+      <form onSubmit={handleSubmit} className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 space-y-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Input
+            label="First Name"
+            required
+            value={form.firstName}
+            onChange={(e) => set('firstName', e.target.value)}
+            error={errors.firstName}
+            placeholder="Ahmed"
+          />
+          <Input
+            label="Last Name"
+            required
+            value={form.lastName}
+            onChange={(e) => set('lastName', e.target.value)}
+            error={errors.lastName}
+            placeholder="Hassan"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Input
+            label="Email"
+            type="email"
+            value={form.email}
+            onChange={(e) => set('email', e.target.value)}
+            error={errors.email}
+            placeholder="ahmed@example.com"
+          />
+          <Input
+            label="Phone"
+            required
+            value={form.phone}
+            onChange={(e) => set('phone', e.target.value)}
+            error={errors.phone}
+            placeholder="+201234567890"
+          />
+        </div>
+
+        <Input
+          label="National ID"
+          value={form.nationalId}
+          onChange={(e) => set('nationalId', e.target.value)}
+          placeholder="Optional"
+        />
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Select
+            label="Client Type"
+            required
+            options={CLIENT_TYPES}
+            value={form.type}
+            onChange={(e) => set('type', e.target.value as ClientType)}
+          />
+          <Select
+            label="Source"
+            options={CLIENT_SOURCES}
+            value={form.source}
+            onChange={(e) => set('source', e.target.value as ClientSource)}
+          />
+        </div>
+
+        <Textarea
+          label="Notes"
+          value={form.notes}
+          onChange={(e) => set('notes', e.target.value)}
+          placeholder="Any additional information..."
+        />
+
+        <div className="flex justify-end gap-3 pt-2">
+          <Button
+            variant="secondary"
+            type="button"
+            onClick={() => navigate(isEdit ? `/clients/${id}` : '/clients')}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" loading={isPending} leftIcon={<Save size={16} />}>
+            {isEdit ? 'Update Client' : 'Create Client'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/clients/ClientsListPage.tsx
+++ b/admin-ui/src/pages/clients/ClientsListPage.tsx
@@ -1,0 +1,222 @@
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Users, Plus, Mail, Phone } from 'lucide-react'
+import { Button, DataTable, SearchBar, Select, StatsCard } from '../../components/ui'
+import { useClientsList, useClientStats, useDeleteClient } from '../../hooks/useClients'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { formatDate } from '../../utils'
+import toast from 'react-hot-toast'
+import type { ClientType, ClientSource, ClientFilter } from '../../types/client'
+import type { Column } from '../../types'
+
+const CLIENT_TYPES: { value: ClientType; label: string }[] = [
+  { value: 'BUYER', label: 'Buyer' },
+  { value: 'SELLER', label: 'Seller' },
+  { value: 'TENANT', label: 'Tenant' },
+  { value: 'LANDLORD', label: 'Landlord' },
+  { value: 'INVESTOR', label: 'Investor' },
+]
+
+const CLIENT_SOURCES: { value: ClientSource; label: string }[] = [
+  { value: 'REFERRAL', label: 'Referral' },
+  { value: 'WEBSITE', label: 'Website' },
+  { value: 'SOCIAL_MEDIA', label: 'Social Media' },
+  { value: 'WALK_IN', label: 'Walk-in' },
+  { value: 'PHONE', label: 'Phone' },
+  { value: 'OTHER', label: 'Other' },
+]
+
+const typeBadge: Record<string, string> = {
+  BUYER: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  SELLER: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  TENANT: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  LANDLORD: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  INVESTOR: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+}
+
+export default function ClientsListPage() {
+  const navigate = useNavigate()
+  const [filter, setFilter] = useState<ClientFilter>({
+    page: 1,
+    pageSize: 10,
+    sortBy: 'createdAt',
+    sortOrder: 'desc',
+  })
+  const [search, setSearch] = useState('')
+  const [deleteId, setDeleteId] = useState<string | null>(null)
+
+  const { data, isLoading } = useClientsList({ ...filter, search: search || undefined })
+  const { data: stats } = useClientStats()
+  const deleteMutation = useDeleteClient()
+
+  const handleSearch = useCallback((q: string) => {
+    setSearch(q)
+    setFilter((f) => ({ ...f, page: 1 }))
+  }, [])
+
+  const handleDelete = async () => {
+    if (!deleteId) return
+    try {
+      await deleteMutation.mutateAsync(deleteId)
+      toast.success('Client deleted')
+      setDeleteId(null)
+    } catch {
+      toast.error('Failed to delete client')
+    }
+  }
+
+  const columns: Column[] = [
+    {
+      key: 'firstName',
+      header: 'Name',
+      sortable: true,
+      render: (_v, row) => (
+        <div className="flex flex-col">
+          <span className="font-medium">{String(row.firstName)} {String(row.lastName)}</span>
+          {row.email && (
+            <span className="flex items-center gap-1 text-xs text-gray-500">
+              <Mail size={10} /> {String(row.email)}
+            </span>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'phone',
+      header: 'Phone',
+      render: (v) => (
+        <span className="flex items-center gap-1.5 text-gray-600 dark:text-gray-400">
+          <Phone size={12} /> {String(v)}
+        </span>
+      ),
+    },
+    {
+      key: 'type',
+      header: 'Type',
+      sortable: true,
+      render: (v) => (
+        <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${typeBadge[String(v)] ?? ''}`}>
+          {String(v)}
+        </span>
+      ),
+    },
+    {
+      key: 'source',
+      header: 'Source',
+      render: (v) => (
+        <span className="text-gray-600 dark:text-gray-400 text-xs">
+          {String(v ?? '').replace('_', ' ')}
+        </span>
+      ),
+    },
+    {
+      key: 'createdAt',
+      header: 'Created',
+      sortable: true,
+      render: (v) => <span className="text-gray-500 text-xs">{formatDate(String(v))}</span>,
+    },
+    {
+      key: 'id',
+      header: '',
+      width: '80px',
+      render: (_v, row) => (
+        <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
+          <button
+            onClick={() => navigate(`/clients/${String(row.id)}/edit`)}
+            className="rounded px-2 py-1 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900/20"
+          >
+            Edit
+          </button>
+          <button
+            onClick={() => setDeleteId(String(row.id))}
+            className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+          >
+            Del
+          </button>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Users size={24} className="text-indigo-500" />
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Clients</h1>
+        </div>
+        <Button leftIcon={<Plus size={16} />} onClick={() => navigate('/clients/new')}>
+          Add Client
+        </Button>
+      </div>
+
+      {/* Stats */}
+      {stats && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <StatsCard title="Total Clients" value={stats.total} icon={Users} color="indigo" />
+          <StatsCard title="Buyers" value={stats.byType?.BUYER ?? 0} icon={Users} color="sky" />
+          <StatsCard title="Sellers" value={stats.byType?.SELLER ?? 0} icon={Users} color="green" />
+          <StatsCard title="Recent (30d)" value={stats.recentCount ?? 0} icon={Users} color="amber" />
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <SearchBar
+          onSearch={handleSearch}
+          placeholder="Search clients..."
+          className="w-64"
+        />
+        <Select
+          options={[{ value: '', label: 'All Types' }, ...CLIENT_TYPES]}
+          value={filter.type ?? ''}
+          onChange={(e) =>
+            setFilter((f) => ({
+              ...f,
+              type: (e.target.value || undefined) as ClientType | undefined,
+              page: 1,
+            }))
+          }
+          className="w-40"
+        />
+        <Select
+          options={[{ value: '', label: 'All Sources' }, ...CLIENT_SOURCES]}
+          value={filter.source ?? ''}
+          onChange={(e) =>
+            setFilter((f) => ({
+              ...f,
+              source: (e.target.value || undefined) as ClientSource | undefined,
+              page: 1,
+            }))
+          }
+          className="w-40"
+        />
+      </div>
+
+      {/* Table */}
+      <DataTable
+        columns={columns}
+        data={(data?.data ?? []) as Record<string, unknown>[]}
+        loading={isLoading}
+        page={filter.page}
+        pageSize={filter.pageSize}
+        total={data?.total}
+        onPageChange={(p) => setFilter((f) => ({ ...f, page: p }))}
+        onPageSizeChange={(ps) => setFilter((f) => ({ ...f, pageSize: ps, page: 1 }))}
+        onRowClick={(row) => navigate(`/clients/${String(row.id)}`)}
+        emptyMessage="No clients found."
+      />
+
+      <ConfirmDialog
+        isOpen={!!deleteId}
+        title="Delete Client"
+        message="Are you sure you want to delete this client? This action cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteId(null)}
+        loading={deleteMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/admin-ui/src/pages/leads/LeadDetailPage.tsx
+++ b/admin-ui/src/pages/leads/LeadDetailPage.tsx
@@ -1,0 +1,326 @@
+import { useState } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import {
+  ArrowLeft,
+  Edit,
+  User,
+  Building2,
+  Calendar,
+  DollarSign,
+  Clock,
+  MessageSquare,
+  Phone,
+  Mail,
+  Video,
+  FileText,
+  Eye,
+  RefreshCw,
+  GitBranch,
+  Plus,
+} from 'lucide-react'
+import { Button, Input, Select, Textarea, LoadingSpinner } from '../../components/ui'
+import { useLeadDetail, useLeadActivities, useAddLeadActivity, useChangeLeadStatus } from '../../hooks/useLeads'
+import { formatDate, formatCurrency, cn } from '../../utils'
+import toast from 'react-hot-toast'
+import type { LeadStatus, LeadActivityType, CreateActivityPayload } from '../../types/lead'
+
+const statusColor: Record<string, string> = {
+  NEW: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  CONTACTED: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  QUALIFIED: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+  PROPOSAL: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  NEGOTIATION: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  WON: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  LOST: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+}
+
+const activityIcon: Record<string, React.ReactNode> = {
+  CALL: <Phone size={14} />,
+  EMAIL: <Mail size={14} />,
+  MEETING: <Video size={14} />,
+  NOTE: <FileText size={14} />,
+  VIEWING: <Eye size={14} />,
+  FOLLOW_UP: <RefreshCw size={14} />,
+  STATUS_CHANGE: <GitBranch size={14} />,
+}
+
+const ACTIVITY_TYPES: { value: LeadActivityType; label: string }[] = [
+  { value: 'CALL', label: 'Call' },
+  { value: 'EMAIL', label: 'Email' },
+  { value: 'MEETING', label: 'Meeting' },
+  { value: 'NOTE', label: 'Note' },
+  { value: 'VIEWING', label: 'Viewing' },
+  { value: 'FOLLOW_UP', label: 'Follow-up' },
+]
+
+const STATUS_OPTIONS: { value: LeadStatus; label: string }[] = [
+  { value: 'NEW', label: 'New' },
+  { value: 'CONTACTED', label: 'Contacted' },
+  { value: 'QUALIFIED', label: 'Qualified' },
+  { value: 'PROPOSAL', label: 'Proposal' },
+  { value: 'NEGOTIATION', label: 'Negotiation' },
+  { value: 'WON', label: 'Won' },
+  { value: 'LOST', label: 'Lost' },
+]
+
+export default function LeadDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { data: lead, isLoading, isError } = useLeadDetail(id!)
+  const { data: activitiesData } = useLeadActivities(id!)
+  const addActivity = useAddLeadActivity()
+  const changeStatus = useChangeLeadStatus()
+
+  const [showActivityForm, setShowActivityForm] = useState(false)
+  const [activityType, setActivityType] = useState<LeadActivityType>('NOTE')
+  const [activityDesc, setActivityDesc] = useState('')
+
+  async function handleAddActivity() {
+    if (!activityDesc.trim()) return
+    try {
+      await addActivity.mutateAsync({
+        id: id!,
+        data: { type: activityType, description: activityDesc.trim() },
+      })
+      toast.success('Activity added')
+      setActivityDesc('')
+      setShowActivityForm(false)
+    } catch {
+      toast.error('Failed to add activity')
+    }
+  }
+
+  async function handleStatusChange(newStatus: LeadStatus) {
+    if (!lead || lead.status === newStatus) return
+    try {
+      await changeStatus.mutateAsync({
+        id: id!,
+        data: { status: newStatus },
+      })
+      toast.success(`Status changed to ${newStatus}`)
+    } catch {
+      toast.error('Invalid status transition')
+    }
+  }
+
+  if (isLoading) return <LoadingSpinner message="Loading lead..." />
+  if (isError || !lead) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16">
+        <p className="text-gray-500">Lead not found.</p>
+        <Button variant="secondary" onClick={() => navigate('/leads')}>
+          Back to Leads
+        </Button>
+      </div>
+    )
+  }
+
+  const activities = activitiesData?.data ?? lead.activities ?? []
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate('/leads')}
+            className="rounded-lg p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800"
+          >
+            <ArrowLeft size={20} />
+          </button>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              Lead &mdash;{' '}
+              {lead.client
+                ? `${lead.client.firstName} ${lead.client.lastName}`
+                : 'Unknown'}
+            </h1>
+            <div className="flex items-center gap-2 mt-1">
+              <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${statusColor[lead.status]}`}>
+                {lead.status}
+              </span>
+              <span className="text-xs text-gray-500">{lead.priority} priority</span>
+            </div>
+          </div>
+        </div>
+        <Button leftIcon={<Edit size={16} />} onClick={() => navigate(`/leads/${id}/edit`)}>
+          Edit Lead
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left: Info */}
+        <div className="lg:col-span-1 space-y-6">
+          {/* Status changer */}
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Change Status</h3>
+            <Select
+              options={STATUS_OPTIONS}
+              value={lead.status}
+              onChange={(e) => handleStatusChange(e.target.value as LeadStatus)}
+              className="w-full"
+            />
+          </div>
+
+          {/* Client Info */}
+          {lead.client && (
+            <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
+                <User size={16} className="text-indigo-500" /> Client
+              </h3>
+              <div className="space-y-2 text-sm">
+                <Link
+                  to={`/clients/${lead.client.id}`}
+                  className="font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
+                >
+                  {lead.client.firstName} {lead.client.lastName}
+                </Link>
+                <p className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+                  <Phone size={12} /> {lead.client.phone}
+                </p>
+                {lead.client.email && (
+                  <p className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+                    <Mail size={12} /> {lead.client.email}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Property */}
+          {lead.property && (
+            <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
+                <Building2 size={16} className="text-indigo-500" /> Property
+              </h3>
+              <Link
+                to={`/properties/${lead.property.id}`}
+                className="text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
+              >
+                {lead.property.title}
+              </Link>
+            </div>
+          )}
+
+          {/* Details */}
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Details</h3>
+            <dl className="space-y-2.5 text-sm">
+              {lead.budget != null && (
+                <div className="flex items-center gap-2">
+                  <DollarSign size={14} className="text-gray-400 shrink-0" />
+                  <dd className="text-gray-700 dark:text-gray-300">Budget: {formatCurrency(lead.budget)}</dd>
+                </div>
+              )}
+              {lead.source && (
+                <div className="flex items-center gap-2">
+                  <MessageSquare size={14} className="text-gray-400 shrink-0" />
+                  <dd className="text-gray-700 dark:text-gray-300">Source: {lead.source}</dd>
+                </div>
+              )}
+              {lead.nextFollowUp && (
+                <div className="flex items-center gap-2">
+                  <Calendar size={14} className="text-gray-400 shrink-0" />
+                  <dd className="text-gray-700 dark:text-gray-300">Follow-up: {formatDate(lead.nextFollowUp)}</dd>
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <Clock size={14} className="text-gray-400 shrink-0" />
+                <dd className="text-gray-700 dark:text-gray-300">Created: {formatDate(lead.createdAt)}</dd>
+              </div>
+              {lead.assignedAgent && (
+                <div className="flex items-center gap-2">
+                  <User size={14} className="text-gray-400 shrink-0" />
+                  <dd className="text-gray-700 dark:text-gray-300">Agent: {lead.assignedAgent.name}</dd>
+                </div>
+              )}
+              {lead.notes && (
+                <div className="pt-2 border-t border-gray-100 dark:border-gray-700">
+                  <dt className="text-xs font-medium text-gray-500 mb-1">Notes</dt>
+                  <dd className="text-gray-700 dark:text-gray-300 whitespace-pre-line">{lead.notes}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        </div>
+
+        {/* Right: Activities */}
+        <div className="lg:col-span-2">
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+                <Clock size={18} className="text-indigo-500" /> Activities
+              </h2>
+              <Button
+                size="sm"
+                variant={showActivityForm ? 'secondary' : 'primary'}
+                leftIcon={<Plus size={14} />}
+                onClick={() => setShowActivityForm(!showActivityForm)}
+              >
+                {showActivityForm ? 'Cancel' : 'Add Activity'}
+              </Button>
+            </div>
+
+            {/* Add Activity Form */}
+            {showActivityForm && (
+              <div className="mb-6 rounded-lg border border-indigo-200 dark:border-indigo-800 bg-indigo-50/50 dark:bg-indigo-900/10 p-4 space-y-3">
+                <Select
+                  label="Type"
+                  options={ACTIVITY_TYPES}
+                  value={activityType}
+                  onChange={(e) => setActivityType(e.target.value as LeadActivityType)}
+                />
+                <Textarea
+                  label="Description"
+                  value={activityDesc}
+                  onChange={(e) => setActivityDesc(e.target.value)}
+                  placeholder="What happened?"
+                  required
+                />
+                <div className="flex justify-end">
+                  <Button
+                    size="sm"
+                    onClick={handleAddActivity}
+                    loading={addActivity.isPending}
+                    disabled={!activityDesc.trim()}
+                  >
+                    Save Activity
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* Activity Timeline */}
+            {activities.length > 0 ? (
+              <div className="relative pl-8 border-l-2 border-gray-200 dark:border-gray-700 space-y-6">
+                {activities.map((act) => (
+                  <div key={act.id} className="relative">
+                    <div className="absolute -left-[2.35rem] top-0.5 flex items-center justify-center w-7 h-7 rounded-full bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 text-gray-500">
+                      {activityIcon[act.type] ?? <FileText size={14} />}
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2 mb-0.5">
+                        <span className="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase">
+                          {act.type.replace('_', ' ')}
+                        </span>
+                        <span className="text-[10px] text-gray-400">
+                          {formatDate(act.createdAt)}
+                        </span>
+                      </div>
+                      <p className="text-sm text-gray-700 dark:text-gray-300">{act.description}</p>
+                      {act.performedByUser && (
+                        <p className="text-[10px] text-gray-400 mt-1">by {act.performedByUser.name}</p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400 text-center py-8">No activities recorded yet.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/leads/LeadFormPage.tsx
+++ b/admin-ui/src/pages/leads/LeadFormPage.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeft, Save } from 'lucide-react'
+import { Button, Input, Select, Textarea, LoadingSpinner } from '../../components/ui'
+import { useLeadDetail, useCreateLead, useUpdateLead } from '../../hooks/useLeads'
+import { useClientsList } from '../../hooks/useClients'
+import toast from 'react-hot-toast'
+import type { LeadStatus, LeadPriority, CreateLeadPayload } from '../../types/lead'
+
+const LEAD_STATUSES: { value: LeadStatus; label: string }[] = [
+  { value: 'NEW', label: 'New' },
+  { value: 'CONTACTED', label: 'Contacted' },
+  { value: 'QUALIFIED', label: 'Qualified' },
+  { value: 'PROPOSAL', label: 'Proposal' },
+  { value: 'NEGOTIATION', label: 'Negotiation' },
+  { value: 'WON', label: 'Won' },
+  { value: 'LOST', label: 'Lost' },
+]
+
+const LEAD_PRIORITIES: { value: LeadPriority; label: string }[] = [
+  { value: 'LOW', label: 'Low' },
+  { value: 'MEDIUM', label: 'Medium' },
+  { value: 'HIGH', label: 'High' },
+  { value: 'URGENT', label: 'Urgent' },
+]
+
+const LEAD_SOURCES = [
+  { value: 'Website', label: 'Website' },
+  { value: 'Referral', label: 'Referral' },
+  { value: 'Social Media', label: 'Social Media' },
+  { value: 'Walk-in', label: 'Walk-in' },
+  { value: 'Phone', label: 'Phone' },
+  { value: 'Other', label: 'Other' },
+]
+
+interface FormState {
+  clientId: string
+  propertyId: string
+  status: LeadStatus
+  priority: LeadPriority
+  source: string
+  budget: string
+  notes: string
+  nextFollowUp: string
+}
+
+const INITIAL: FormState = {
+  clientId: '',
+  propertyId: '',
+  status: 'NEW',
+  priority: 'MEDIUM',
+  source: '',
+  budget: '',
+  notes: '',
+  nextFollowUp: '',
+}
+
+export default function LeadFormPage() {
+  const { id } = useParams<{ id: string }>()
+  const isEdit = !!id
+  const navigate = useNavigate()
+  const [form, setForm] = useState<FormState>(INITIAL)
+  const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({})
+
+  const { data: existing, isLoading: loadingExisting } = useLeadDetail(id ?? '')
+  const { data: clientsData } = useClientsList({ page: 1, pageSize: 200 })
+  const createMutation = useCreateLead()
+  const updateMutation = useUpdateLead()
+
+  useEffect(() => {
+    if (existing && isEdit) {
+      setForm({
+        clientId: existing.clientId,
+        propertyId: existing.propertyId ?? '',
+        status: existing.status,
+        priority: existing.priority,
+        source: existing.source ?? '',
+        budget: existing.budget != null ? String(existing.budget) : '',
+        notes: existing.notes ?? '',
+        nextFollowUp: existing.nextFollowUp
+          ? new Date(existing.nextFollowUp).toISOString().slice(0, 16)
+          : '',
+      })
+    }
+  }, [existing, isEdit])
+
+  function set<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => ({ ...f, [key]: value }))
+    setErrors((e) => ({ ...e, [key]: undefined }))
+  }
+
+  function validate(): boolean {
+    const errs: Partial<Record<keyof FormState, string>> = {}
+    if (!form.clientId) errs.clientId = 'Client is required'
+    if (form.budget && isNaN(Number(form.budget))) errs.budget = 'Budget must be a number'
+    setErrors(errs)
+    return Object.keys(errs).length === 0
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+
+    const payload: CreateLeadPayload = {
+      clientId: form.clientId,
+      status: form.status,
+      priority: form.priority,
+      ...(form.propertyId ? { propertyId: form.propertyId } : {}),
+      ...(form.source ? { source: form.source } : {}),
+      ...(form.budget ? { budget: Number(form.budget) } : {}),
+      ...(form.notes ? { notes: form.notes.trim() } : {}),
+      ...(form.nextFollowUp ? { nextFollowUp: new Date(form.nextFollowUp).toISOString() } : {}),
+    }
+
+    try {
+      if (isEdit) {
+        await updateMutation.mutateAsync({ id: id!, data: payload })
+        toast.success('Lead updated')
+        navigate(`/leads/${id}`)
+      } else {
+        const created = await createMutation.mutateAsync(payload)
+        toast.success('Lead created')
+        navigate(`/leads/${created.id}`)
+      }
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'response' in err
+          ? String((err as { response?: { data?: { message?: string } } }).response?.data?.message ?? 'Something went wrong')
+          : 'Something went wrong'
+      toast.error(message)
+    }
+  }
+
+  const clientOptions = (clientsData?.data ?? []).map((c) => ({
+    value: c.id,
+    label: `${c.firstName} ${c.lastName} (${c.phone})`,
+  }))
+
+  if (isEdit && loadingExisting) return <LoadingSpinner message="Loading lead..." />
+
+  const isPending = createMutation.isPending || updateMutation.isPending
+
+  return (
+    <div className="flex flex-col gap-6 max-w-2xl">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => navigate(isEdit ? `/leads/${id}` : '/leads')}
+          className="rounded-lg p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800"
+        >
+          <ArrowLeft size={20} />
+        </button>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          {isEdit ? 'Edit Lead' : 'New Lead'}
+        </h1>
+      </div>
+
+      <form onSubmit={handleSubmit} className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 space-y-5">
+        <Select
+          label="Client"
+          required
+          options={clientOptions}
+          placeholder="Select a client..."
+          value={form.clientId}
+          onChange={(e) => set('clientId', e.target.value)}
+          error={errors.clientId}
+        />
+
+        <Input
+          label="Property ID"
+          value={form.propertyId}
+          onChange={(e) => set('propertyId', e.target.value)}
+          placeholder="Optional property UUID"
+          hint="Leave empty if no specific property"
+        />
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Select
+            label="Status"
+            options={LEAD_STATUSES}
+            value={form.status}
+            onChange={(e) => set('status', e.target.value as LeadStatus)}
+          />
+          <Select
+            label="Priority"
+            options={LEAD_PRIORITIES}
+            value={form.priority}
+            onChange={(e) => set('priority', e.target.value as LeadPriority)}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Select
+            label="Source"
+            options={[{ value: '', label: 'None' }, ...LEAD_SOURCES]}
+            value={form.source}
+            onChange={(e) => set('source', e.target.value)}
+          />
+          <Input
+            label="Budget"
+            type="number"
+            value={form.budget}
+            onChange={(e) => set('budget', e.target.value)}
+            error={errors.budget}
+            placeholder="500000"
+          />
+        </div>
+
+        <Input
+          label="Next Follow-up"
+          type="datetime-local"
+          value={form.nextFollowUp}
+          onChange={(e) => set('nextFollowUp', e.target.value)}
+        />
+
+        <Textarea
+          label="Notes"
+          value={form.notes}
+          onChange={(e) => set('notes', e.target.value)}
+          placeholder="Any additional details..."
+        />
+
+        <div className="flex justify-end gap-3 pt-2">
+          <Button
+            variant="secondary"
+            type="button"
+            onClick={() => navigate(isEdit ? `/leads/${id}` : '/leads')}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" loading={isPending} leftIcon={<Save size={16} />}>
+            {isEdit ? 'Update Lead' : 'Create Lead'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/leads/LeadsKanbanPage.tsx
+++ b/admin-ui/src/pages/leads/LeadsKanbanPage.tsx
@@ -1,0 +1,186 @@
+import { useState, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { UserCheck, Plus, List, GripVertical } from 'lucide-react'
+import { Button, LoadingSpinner } from '../../components/ui'
+import { useLeadPipeline, useChangeLeadStatus } from '../../hooks/useLeads'
+import { formatDate, formatCurrency, cn } from '../../utils'
+import toast from 'react-hot-toast'
+import type { Lead, LeadStatus } from '../../types/lead'
+
+const PIPELINE_STAGES: { status: LeadStatus; label: string; color: string; bg: string }[] = [
+  { status: 'NEW', label: 'New', color: 'border-gray-300 dark:border-gray-600', bg: 'bg-gray-50 dark:bg-gray-800/50' },
+  { status: 'CONTACTED', label: 'Contacted', color: 'border-blue-300 dark:border-blue-700', bg: 'bg-blue-50/50 dark:bg-blue-900/10' },
+  { status: 'QUALIFIED', label: 'Qualified', color: 'border-indigo-300 dark:border-indigo-700', bg: 'bg-indigo-50/50 dark:bg-indigo-900/10' },
+  { status: 'NEGOTIATION', label: 'Negotiation', color: 'border-amber-300 dark:border-amber-700', bg: 'bg-amber-50/50 dark:bg-amber-900/10' },
+  { status: 'WON', label: 'Won', color: 'border-green-300 dark:border-green-700', bg: 'bg-green-50/50 dark:bg-green-900/10' },
+  { status: 'LOST', label: 'Lost', color: 'border-red-300 dark:border-red-700', bg: 'bg-red-50/50 dark:bg-red-900/10' },
+]
+
+const priorityDot: Record<string, string> = {
+  LOW: 'bg-gray-400',
+  MEDIUM: 'bg-blue-500',
+  HIGH: 'bg-amber-500',
+  URGENT: 'bg-red-500',
+}
+
+export default function LeadsKanbanPage() {
+  const navigate = useNavigate()
+  const { data: pipeline, isLoading } = useLeadPipeline()
+  const changeStatus = useChangeLeadStatus()
+  const [draggedLead, setDraggedLead] = useState<Lead | null>(null)
+  const [dragOverStage, setDragOverStage] = useState<LeadStatus | null>(null)
+
+  function handleDragStart(e: React.DragEvent, lead: Lead) {
+    setDraggedLead(lead)
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', lead.id)
+  }
+
+  function handleDragOver(e: React.DragEvent, status: LeadStatus) {
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    setDragOverStage(status)
+  }
+
+  function handleDragLeave() {
+    setDragOverStage(null)
+  }
+
+  async function handleDrop(e: React.DragEvent, newStatus: LeadStatus) {
+    e.preventDefault()
+    setDragOverStage(null)
+    if (!draggedLead || draggedLead.status === newStatus) {
+      setDraggedLead(null)
+      return
+    }
+
+    try {
+      await changeStatus.mutateAsync({
+        id: draggedLead.id,
+        data: { status: newStatus, notes: `Moved to ${newStatus} via kanban` },
+      })
+      toast.success(`Lead moved to ${newStatus}`)
+    } catch {
+      toast.error('Failed to change lead status')
+    }
+    setDraggedLead(null)
+  }
+
+  if (isLoading) return <LoadingSpinner message="Loading pipeline..." />
+
+  return (
+    <div className="flex flex-col gap-6 h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <UserCheck size={24} className="text-indigo-500" />
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Lead Pipeline</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            leftIcon={<List size={16} />}
+            onClick={() => navigate('/leads')}
+          >
+            List View
+          </Button>
+          <Button leftIcon={<Plus size={16} />} onClick={() => navigate('/leads/new')}>
+            Add Lead
+          </Button>
+        </div>
+      </div>
+
+      {/* Kanban Board */}
+      <div className="flex gap-4 overflow-x-auto pb-4 min-h-[500px]">
+        {PIPELINE_STAGES.map((stage) => {
+          const leads = (pipeline?.[stage.status] ?? []) as Lead[]
+          const isOver = dragOverStage === stage.status
+
+          return (
+            <div
+              key={stage.status}
+              className={cn(
+                'flex flex-col w-72 min-w-[18rem] shrink-0 rounded-xl border-2 transition-colors',
+                stage.color,
+                isOver && 'border-indigo-500 dark:border-indigo-400 shadow-lg',
+              )}
+              onDragOver={(e) => handleDragOver(e, stage.status)}
+              onDragLeave={handleDragLeave}
+              onDrop={(e) => handleDrop(e, stage.status)}
+            >
+              {/* Stage Header */}
+              <div className={cn('flex items-center justify-between px-4 py-3 rounded-t-xl', stage.bg)}>
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                  {stage.label}
+                </h3>
+                <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-white dark:bg-gray-700 text-xs font-bold text-gray-600 dark:text-gray-300 shadow-sm">
+                  {leads.length}
+                </span>
+              </div>
+
+              {/* Cards */}
+              <div className="flex-1 p-2 space-y-2 overflow-y-auto max-h-[calc(100vh-260px)]">
+                {leads.map((lead) => (
+                  <div
+                    key={lead.id}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, lead)}
+                    onClick={() => navigate(`/leads/${lead.id}`)}
+                    className={cn(
+                      'group rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 cursor-pointer',
+                      'hover:shadow-md hover:border-indigo-300 dark:hover:border-indigo-600 transition-all',
+                      draggedLead?.id === lead.id && 'opacity-40',
+                    )}
+                  >
+                    <div className="flex items-start justify-between mb-2">
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100 leading-tight">
+                        {lead.client
+                          ? `${lead.client.firstName} ${lead.client.lastName}`
+                          : 'Unknown'}
+                      </span>
+                      <GripVertical
+                        size={14}
+                        className="text-gray-300 dark:text-gray-600 shrink-0 mt-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+                      />
+                    </div>
+
+                    {lead.property && (
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mb-2 truncate">
+                        {lead.property.title}
+                      </p>
+                    )}
+
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-1.5">
+                        <span className={cn('w-2 h-2 rounded-full', priorityDot[lead.priority])} />
+                        <span className="text-[10px] text-gray-400 uppercase">{lead.priority}</span>
+                      </div>
+                      {lead.budget && (
+                        <span className="text-[10px] font-medium text-gray-500">
+                          {formatCurrency(lead.budget)}
+                        </span>
+                      )}
+                    </div>
+
+                    {lead.nextFollowUp && (
+                      <p className="mt-2 text-[10px] text-gray-400">
+                        Follow-up: {formatDate(lead.nextFollowUp)}
+                      </p>
+                    )}
+                  </div>
+                ))}
+
+                {leads.length === 0 && (
+                  <div className="flex items-center justify-center h-24 text-xs text-gray-400 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg">
+                    No leads
+                  </div>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/leads/LeadsListPage.tsx
+++ b/admin-ui/src/pages/leads/LeadsListPage.tsx
@@ -1,0 +1,260 @@
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { UserCheck, Plus, LayoutGrid, List } from 'lucide-react'
+import { Button, DataTable, SearchBar, Select, StatsCard } from '../../components/ui'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { useLeadsList, useLeadStats, useDeleteLead } from '../../hooks/useLeads'
+import { formatDate, formatCurrency } from '../../utils'
+import toast from 'react-hot-toast'
+import type { LeadStatus, LeadPriority, LeadFilter } from '../../types/lead'
+import type { Column } from '../../types'
+
+const LEAD_STATUSES: { value: LeadStatus; label: string }[] = [
+  { value: 'NEW', label: 'New' },
+  { value: 'CONTACTED', label: 'Contacted' },
+  { value: 'QUALIFIED', label: 'Qualified' },
+  { value: 'PROPOSAL', label: 'Proposal' },
+  { value: 'NEGOTIATION', label: 'Negotiation' },
+  { value: 'WON', label: 'Won' },
+  { value: 'LOST', label: 'Lost' },
+]
+
+const LEAD_PRIORITIES: { value: LeadPriority; label: string }[] = [
+  { value: 'LOW', label: 'Low' },
+  { value: 'MEDIUM', label: 'Medium' },
+  { value: 'HIGH', label: 'High' },
+  { value: 'URGENT', label: 'Urgent' },
+]
+
+const statusBadge: Record<string, string> = {
+  NEW: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  CONTACTED: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  QUALIFIED: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+  PROPOSAL: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  NEGOTIATION: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  WON: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  LOST: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+}
+
+const priorityBadge: Record<string, string> = {
+  LOW: 'text-gray-500',
+  MEDIUM: 'text-blue-600 dark:text-blue-400',
+  HIGH: 'text-amber-600 dark:text-amber-400',
+  URGENT: 'text-red-600 dark:text-red-400',
+}
+
+export default function LeadsListPage() {
+  const navigate = useNavigate()
+  const [filter, setFilter] = useState<LeadFilter>({
+    page: 1,
+    pageSize: 10,
+    sortBy: 'createdAt',
+    sortOrder: 'desc',
+  })
+  const [search, setSearch] = useState('')
+  const [deleteId, setDeleteId] = useState<string | null>(null)
+
+  const { data, isLoading } = useLeadsList({ ...filter, search: search || undefined })
+  const { data: stats } = useLeadStats()
+  const deleteMutation = useDeleteLead()
+
+  const handleSearch = useCallback((q: string) => {
+    setSearch(q)
+    setFilter((f) => ({ ...f, page: 1 }))
+  }, [])
+
+  const handleDelete = async () => {
+    if (!deleteId) return
+    try {
+      await deleteMutation.mutateAsync(deleteId)
+      toast.success('Lead deleted')
+      setDeleteId(null)
+    } catch {
+      toast.error('Failed to delete lead')
+    }
+  }
+
+  const columns: Column[] = [
+    {
+      key: 'client',
+      header: 'Client',
+      render: (_v, row) => {
+        const c = row.client as { firstName?: string; lastName?: string } | undefined
+        return (
+          <span className="font-medium text-gray-900 dark:text-gray-100">
+            {c ? `${c.firstName} ${c.lastName}` : 'N/A'}
+          </span>
+        )
+      },
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      sortable: true,
+      render: (v) => (
+        <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${statusBadge[String(v)] ?? ''}`}>
+          {String(v)}
+        </span>
+      ),
+    },
+    {
+      key: 'priority',
+      header: 'Priority',
+      sortable: true,
+      render: (v) => (
+        <span className={`text-xs font-semibold ${priorityBadge[String(v)] ?? ''}`}>
+          {String(v)}
+        </span>
+      ),
+    },
+    {
+      key: 'property',
+      header: 'Property',
+      render: (_v, row) => {
+        const p = row.property as { title?: string } | undefined
+        return (
+          <span className="text-sm text-gray-600 dark:text-gray-400">
+            {p?.title ?? '--'}
+          </span>
+        )
+      },
+    },
+    {
+      key: 'budget',
+      header: 'Budget',
+      render: (v) => (
+        <span className="text-sm">{v ? formatCurrency(Number(v)) : '--'}</span>
+      ),
+    },
+    {
+      key: 'nextFollowUp',
+      header: 'Follow-up',
+      sortable: true,
+      render: (v) => (
+        <span className="text-xs text-gray-500">
+          {v ? formatDate(String(v)) : '--'}
+        </span>
+      ),
+    },
+    {
+      key: 'createdAt',
+      header: 'Created',
+      sortable: true,
+      render: (v) => <span className="text-xs text-gray-500">{formatDate(String(v))}</span>,
+    },
+    {
+      key: 'id',
+      header: '',
+      width: '80px',
+      render: (_v, row) => (
+        <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
+          <button
+            onClick={() => navigate(`/leads/${String(row.id)}/edit`)}
+            className="rounded px-2 py-1 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900/20"
+          >
+            Edit
+          </button>
+          <button
+            onClick={() => setDeleteId(String(row.id))}
+            className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+          >
+            Del
+          </button>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <UserCheck size={24} className="text-indigo-500" />
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Leads</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            leftIcon={<LayoutGrid size={16} />}
+            onClick={() => navigate('/leads/kanban')}
+          >
+            Kanban
+          </Button>
+          <Button leftIcon={<Plus size={16} />} onClick={() => navigate('/leads/new')}>
+            Add Lead
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      {stats && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <StatsCard title="Total Leads" value={stats.total} icon={UserCheck} color="indigo" />
+          <StatsCard title="New" value={stats.byStatus?.NEW ?? 0} icon={UserCheck} color="sky" />
+          <StatsCard title="Won" value={stats.byStatus?.WON ?? 0} icon={UserCheck} color="green" />
+          <StatsCard
+            title="Conversion Rate"
+            value={`${(stats.conversionRate ?? 0).toFixed(1)}%`}
+            icon={UserCheck}
+            color="purple"
+          />
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <SearchBar onSearch={handleSearch} placeholder="Search leads..." className="w-64" />
+        <Select
+          options={[{ value: '', label: 'All Statuses' }, ...LEAD_STATUSES]}
+          value={filter.status ?? ''}
+          onChange={(e) =>
+            setFilter((f) => ({
+              ...f,
+              status: (e.target.value || undefined) as LeadStatus | undefined,
+              page: 1,
+            }))
+          }
+          className="w-40"
+        />
+        <Select
+          options={[{ value: '', label: 'All Priorities' }, ...LEAD_PRIORITIES]}
+          value={filter.priority ?? ''}
+          onChange={(e) =>
+            setFilter((f) => ({
+              ...f,
+              priority: (e.target.value || undefined) as LeadPriority | undefined,
+              page: 1,
+            }))
+          }
+          className="w-40"
+        />
+      </div>
+
+      {/* Table */}
+      <DataTable
+        columns={columns}
+        data={(data?.data ?? []) as Record<string, unknown>[]}
+        loading={isLoading}
+        page={filter.page}
+        pageSize={filter.pageSize}
+        total={data?.total}
+        onPageChange={(p) => setFilter((f) => ({ ...f, page: p }))}
+        onPageSizeChange={(ps) => setFilter((f) => ({ ...f, pageSize: ps, page: 1 }))}
+        onRowClick={(row) => navigate(`/leads/${String(row.id)}`)}
+        emptyMessage="No leads found."
+      />
+
+      <ConfirmDialog
+        isOpen={!!deleteId}
+        title="Delete Lead"
+        message="Are you sure? The lead will be marked as LOST."
+        confirmLabel="Delete"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteId(null)}
+        loading={deleteMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/admin-ui/src/types/client.ts
+++ b/admin-ui/src/types/client.ts
@@ -1,0 +1,86 @@
+export type ClientType = 'BUYER' | 'SELLER' | 'TENANT' | 'LANDLORD' | 'INVESTOR'
+export type ClientSource = 'REFERRAL' | 'WEBSITE' | 'SOCIAL_MEDIA' | 'WALK_IN' | 'PHONE' | 'OTHER'
+
+export interface Client {
+  id: string
+  firstName: string
+  lastName: string
+  email?: string | null
+  phone: string
+  nationalId?: string | null
+  type: ClientType
+  source: ClientSource
+  notes?: string | null
+  assignedAgentId?: string | null
+  assignedAgent?: { id: string; name: string } | null
+  createdAt: string
+  updatedAt: string
+  _count?: { leads?: number; contracts?: number }
+}
+
+export interface ClientDetail extends Client {
+  leads: {
+    id: string
+    status: string
+    priority: string
+    source?: string | null
+    createdAt: string
+    property?: { id: string; title: string } | null
+  }[]
+  contracts: {
+    id: string
+    type: string
+    status: string
+    totalAmount: number
+    createdAt: string
+    property?: { id: string; title: string } | null
+  }[]
+}
+
+export interface ClientHistory {
+  leads: {
+    id: string
+    status: string
+    priority: string
+    createdAt: string
+    property?: { id: string; title: string } | null
+  }[]
+  contracts: {
+    id: string
+    type: string
+    status: string
+    totalAmount: number
+    createdAt: string
+  }[]
+}
+
+export interface CreateClientPayload {
+  firstName: string
+  lastName: string
+  email?: string
+  phone: string
+  nationalId?: string
+  type: ClientType
+  source?: ClientSource
+  notes?: string
+}
+
+export interface UpdateClientPayload extends Partial<CreateClientPayload> {}
+
+export interface ClientFilter {
+  page?: number
+  pageSize?: number
+  search?: string
+  type?: ClientType
+  source?: ClientSource
+  assignedAgentId?: string
+  sortBy?: 'createdAt' | 'firstName' | 'lastName'
+  sortOrder?: 'asc' | 'desc'
+}
+
+export interface ClientStats {
+  total: number
+  byType: Record<ClientType, number>
+  bySource: Record<ClientSource, number>
+  recentCount: number
+}

--- a/admin-ui/src/types/lead.ts
+++ b/admin-ui/src/types/lead.ts
@@ -1,0 +1,83 @@
+export type LeadStatus = 'NEW' | 'CONTACTED' | 'QUALIFIED' | 'PROPOSAL' | 'NEGOTIATION' | 'WON' | 'LOST'
+export type LeadPriority = 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT'
+export type LeadActivityType = 'CALL' | 'EMAIL' | 'MEETING' | 'NOTE' | 'VIEWING' | 'FOLLOW_UP' | 'STATUS_CHANGE'
+
+export interface Lead {
+  id: string
+  clientId: string
+  client?: { id: string; firstName: string; lastName: string; phone: string; email?: string | null }
+  propertyId?: string | null
+  property?: { id: string; title: string } | null
+  status: LeadStatus
+  priority: LeadPriority
+  source?: string | null
+  budget?: number | null
+  notes?: string | null
+  assignedAgentId?: string | null
+  assignedAgent?: { id: string; name: string } | null
+  nextFollowUp?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface LeadDetail extends Lead {
+  activities: LeadActivity[]
+}
+
+export interface LeadActivity {
+  id: string
+  leadId: string
+  type: LeadActivityType
+  description: string
+  performedBy?: string | null
+  performedByUser?: { id: string; name: string } | null
+  createdAt: string
+}
+
+export interface CreateLeadPayload {
+  clientId: string
+  propertyId?: string
+  status?: LeadStatus
+  priority?: LeadPriority
+  source?: string
+  budget?: number
+  notes?: string
+  assignedAgentId?: string
+  nextFollowUp?: string
+}
+
+export interface UpdateLeadPayload extends Partial<CreateLeadPayload> {}
+
+export interface LeadFilter {
+  page?: number
+  pageSize?: number
+  search?: string
+  status?: LeadStatus
+  priority?: LeadPriority
+  assignedAgentId?: string
+  dateFrom?: string
+  dateTo?: string
+  sortBy?: 'createdAt' | 'priority' | 'nextFollowUp'
+  sortOrder?: 'asc' | 'desc'
+}
+
+export interface PipelineData {
+  [status: string]: Lead[]
+}
+
+export interface LeadStats {
+  total: number
+  byStatus: Record<LeadStatus, number>
+  byPriority: Record<LeadPriority, number>
+  conversionRate: number
+}
+
+export interface ChangeStatusPayload {
+  status: LeadStatus
+  notes?: string
+}
+
+export interface CreateActivityPayload {
+  type: LeadActivityType
+  description: string
+}


### PR DESCRIPTION
## Summary
- **Client management pages**: list with filters/search/pagination, detail view with leads/contracts/activity history, create/edit form with validation
- **Lead management pages**: list with status/priority filters, kanban pipeline board with drag-and-drop (New -> Contacted -> Qualified -> Negotiation -> Won/Lost), detail view with activity timeline and status changer, create/edit form with client selector
- **API layers & hooks**: full CRUD for both clients and leads, React Query hooks with smart cache invalidation, pipeline endpoint integration

## Files added/modified (14 files, ~2200 lines)
- `admin-ui/src/types/client.ts` & `types/lead.ts` — TypeScript interfaces & enums
- `admin-ui/src/api/clients.ts` & `api/leads.ts` — Axios API wrappers
- `admin-ui/src/hooks/useClients.ts` & `hooks/useLeads.ts` — React Query hooks
- `admin-ui/src/pages/clients/` — ClientsListPage, ClientDetailPage, ClientFormPage
- `admin-ui/src/pages/leads/` — LeadsListPage, LeadsKanbanPage, LeadDetailPage, LeadFormPage
- `admin-ui/src/App.tsx` — Updated routes

## Test plan
- [ ] Verify clients list page loads with search, type/source filters, and pagination
- [ ] Verify client create/edit form with validation (required fields, phone format, email format)
- [ ] Verify client detail page shows leads, contracts, and activity history
- [ ] Verify leads list page with status/priority filters
- [ ] Verify kanban board renders pipeline stages and drag-drop changes lead status
- [ ] Verify lead detail page shows client info, property, activities timeline
- [ ] Verify lead create/edit form with client dropdown selector
- [ ] Verify all routes accessible from sidebar navigation

Closes #17