### PR TITLE
feat(admin): Reports & Agent Management (#19)

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -18,11 +18,15 @@ import LeadsListPage from './pages/leads/LeadsListPage'
 import LeadsKanbanPage from './pages/leads/LeadsKanbanPage'
 import LeadDetailPage from './pages/leads/LeadDetailPage'
 import LeadFormPage from './pages/leads/LeadFormPage'
-import ContractsPage from './pages/ContractsPage'
-import InvoicesPage from './pages/InvoicesPage'
-import ReportsPage from './pages/ReportsPage'
-import AgentsPage from './pages/AgentsPage'
-import SettingsPage from './pages/SettingsPage'
+import ContractsListPage from './pages/contracts/ContractsListPage'
+import ContractDetailPage from './pages/contracts/ContractDetailPage'
+import ContractFormPage from './pages/contracts/ContractFormPage'
+import InvoicesListPage from './pages/invoices/InvoicesListPage'
+import InvoiceDetailPage from './pages/invoices/InvoiceDetailPage'
+import ReportsPage from './pages/reports/ReportsPage'
+import AgentsListPage from './pages/agents/AgentsListPage'
+import AgentDetailPage from './pages/agents/AgentDetailPage'
+import SettingsPage from './pages/settings/SettingsPage'
 
 export default function App() {
   return (
@@ -57,10 +61,15 @@ export default function App() {
                 <Route path="leads/new" element={<LeadFormPage />} />
                 <Route path="leads/:id" element={<LeadDetailPage />} />
                 <Route path="leads/:id/edit" element={<LeadFormPage />} />
-                <Route path="contracts" element={<ContractsPage />} />
-                <Route path="invoices" element={<InvoicesPage />} />
+                <Route path="contracts" element={<ContractsListPage />} />
+                <Route path="contracts/new" element={<ContractFormPage />} />
+                <Route path="contracts/:id" element={<ContractDetailPage />} />
+                <Route path="contracts/:id/edit" element={<ContractFormPage />} />
+                <Route path="invoices" element={<InvoicesListPage />} />
+                <Route path="invoices/:id" element={<InvoiceDetailPage />} />
                 <Route path="reports" element={<ReportsPage />} />
-                <Route path="agents" element={<AgentsPage />} />
+                <Route path="agents" element={<AgentsListPage />} />
+                <Route path="agents/:id" element={<AgentDetailPage />} />
                 <Route path="settings" element={<SettingsPage />} />
               </Route>
             </Routes>

--- a/admin-ui/src/api/agents.ts
+++ b/admin-ui/src/api/agents.ts
@@ -1,0 +1,25 @@
+import apiClient from './client'
+import type { PaginatedResponse } from '../types'
+import type { Agent, AgentDetail } from '../types/reports'
+
+const BASE = '/api/users'
+
+export const agentsApi = {
+  list(params?: { page?: number; limit?: number; search?: string }) {
+    return apiClient
+      .get<PaginatedResponse<Agent>>(BASE, {
+        params: { ...params, role: 'AGENT' },
+      })
+      .then((r) => r.data)
+  },
+
+  getById(id: string) {
+    return apiClient.get<AgentDetail>(`${BASE}/${id}`).then((r) => r.data)
+  },
+
+  toggleActive(id: string, isActive: boolean) {
+    return apiClient
+      .patch<Agent>(`${BASE}/${id}/status`, { isActive })
+      .then((r) => r.data)
+  },
+}

--- a/admin-ui/src/api/contracts.ts
+++ b/admin-ui/src/api/contracts.ts
@@ -1,0 +1,63 @@
+import apiClient from './client'
+import type { PaginatedResponse } from '../types'
+import type {
+  Contract,
+  ContractDetail,
+  ContractFilter,
+  ContractStats,
+  CreateContractPayload,
+  UpdateContractPayload,
+  ChangeContractStatusPayload,
+  GenerateInvoicesPayload,
+} from '../types/contract'
+import type { Invoice } from '../types/invoice'
+
+const BASE = '/api/contracts'
+
+export const contractsApi = {
+  list(filter?: ContractFilter) {
+    return apiClient
+      .get<PaginatedResponse<Contract>>(BASE, { params: filter })
+      .then((r) => r.data)
+  },
+
+  getById(id: string) {
+    return apiClient.get<ContractDetail>(`${BASE}/${id}`).then((r) => r.data)
+  },
+
+  getStats() {
+    return apiClient.get<ContractStats>(`${BASE}/stats`).then((r) => r.data)
+  },
+
+  getExpiring(days = 30) {
+    return apiClient
+      .get<Contract[]>(`${BASE}/expiring`, { params: { days } })
+      .then((r) => r.data)
+  },
+
+  getInvoices(id: string) {
+    return apiClient
+      .get<Invoice[]>(`${BASE}/${id}/invoices`)
+      .then((r) => r.data)
+  },
+
+  create(data: CreateContractPayload) {
+    return apiClient.post<Contract>(BASE, data).then((r) => r.data)
+  },
+
+  update(id: string, data: UpdateContractPayload) {
+    return apiClient.put<Contract>(`${BASE}/${id}`, data).then((r) => r.data)
+  },
+
+  changeStatus(id: string, data: ChangeContractStatusPayload) {
+    return apiClient
+      .patch<Contract>(`${BASE}/${id}/status`, data)
+      .then((r) => r.data)
+  },
+
+  generateInvoices(id: string, data?: GenerateInvoicesPayload) {
+    return apiClient
+      .post<Invoice[]>(`${BASE}/${id}/generate-invoices`, data ?? {})
+      .then((r) => r.data)
+  },
+}

--- a/admin-ui/src/api/invoices.ts
+++ b/admin-ui/src/api/invoices.ts
@@ -1,0 +1,59 @@
+import apiClient from './client'
+import type { PaginatedResponse } from '../types'
+import type {
+  Invoice,
+  InvoiceDetail,
+  InvoiceFilter,
+  InvoiceStats,
+  CreateInvoicePayload,
+  UpdateInvoicePayload,
+  RecordPaymentPayload,
+} from '../types/invoice'
+
+const BASE = '/api/invoices'
+
+export const invoicesApi = {
+  list(filter?: InvoiceFilter) {
+    return apiClient
+      .get<PaginatedResponse<Invoice>>(BASE, { params: filter })
+      .then((r) => r.data)
+  },
+
+  getById(id: string) {
+    return apiClient.get<InvoiceDetail>(`${BASE}/${id}`).then((r) => r.data)
+  },
+
+  getStats() {
+    return apiClient.get<InvoiceStats>(`${BASE}/stats`).then((r) => r.data)
+  },
+
+  getOverdue() {
+    return apiClient.get<Invoice[]>(`${BASE}/overdue`).then((r) => r.data)
+  },
+
+  getUpcoming(days = 30) {
+    return apiClient
+      .get<Invoice[]>(`${BASE}/upcoming`, { params: { days } })
+      .then((r) => r.data)
+  },
+
+  create(data: CreateInvoicePayload) {
+    return apiClient.post<Invoice>(BASE, data).then((r) => r.data)
+  },
+
+  update(id: string, data: UpdateInvoicePayload) {
+    return apiClient.put<Invoice>(`${BASE}/${id}`, data).then((r) => r.data)
+  },
+
+  recordPayment(id: string, data: RecordPaymentPayload) {
+    return apiClient
+      .patch<Invoice>(`${BASE}/${id}/pay`, data)
+      .then((r) => r.data)
+  },
+
+  cancel(id: string) {
+    return apiClient
+      .patch<Invoice>(`${BASE}/${id}/cancel`)
+      .then((r) => r.data)
+  },
+}

--- a/admin-ui/src/api/reports.ts
+++ b/admin-ui/src/api/reports.ts
@@ -1,0 +1,48 @@
+import apiClient from './client'
+import type {
+  RevenueReportParams,
+  RevenueReportResponse,
+  LeadConversionParams,
+  LeadConversionResponse,
+  PropertyReportResponse,
+} from '../types/reports'
+
+const BASE = '/api/reports'
+
+export const reportsApi = {
+  getRevenue(params?: RevenueReportParams) {
+    return apiClient
+      .get<RevenueReportResponse>(`${BASE}/revenue`, { params })
+      .then((r) => r.data)
+  },
+
+  getLeadConversion(params?: LeadConversionParams) {
+    return apiClient
+      .get<LeadConversionResponse>(`${BASE}/leads/conversion`, { params })
+      .then((r) => r.data)
+  },
+
+  getProperties() {
+    return apiClient
+      .get<PropertyReportResponse>(`${BASE}/properties`)
+      .then((r) => r.data)
+  },
+
+  exportRevenueCsv(params?: RevenueReportParams) {
+    return apiClient
+      .get(`${BASE}/revenue/export`, {
+        params,
+        responseType: 'blob',
+      })
+      .then((r) => r.data)
+  },
+
+  exportLeadsCsv(params?: LeadConversionParams) {
+    return apiClient
+      .get(`${BASE}/leads/export`, {
+        params,
+        responseType: 'blob',
+      })
+      .then((r) => r.data)
+  },
+}

--- a/admin-ui/src/api/settings.ts
+++ b/admin-ui/src/api/settings.ts
@@ -1,0 +1,42 @@
+import apiClient from './client'
+import type { CompanySettings, ConfigItem } from '../types/reports'
+
+const BASE = '/api/settings'
+
+export const settingsApi = {
+  getCompany() {
+    return apiClient
+      .get<CompanySettings>(`${BASE}/company`)
+      .then((r) => r.data)
+  },
+
+  updateCompany(data: CompanySettings) {
+    return apiClient
+      .put<CompanySettings>(`${BASE}/company`, data)
+      .then((r) => r.data)
+  },
+
+  getPropertyTypes() {
+    return apiClient
+      .get<ConfigItem[]>(`${BASE}/property-types`)
+      .then((r) => r.data)
+  },
+
+  updatePropertyTypes(items: ConfigItem[]) {
+    return apiClient
+      .put<ConfigItem[]>(`${BASE}/property-types`, { items })
+      .then((r) => r.data)
+  },
+
+  getLeadSources() {
+    return apiClient
+      .get<ConfigItem[]>(`${BASE}/lead-sources`)
+      .then((r) => r.data)
+  },
+
+  updateLeadSources(items: ConfigItem[]) {
+    return apiClient
+      .put<ConfigItem[]>(`${BASE}/lead-sources`, { items })
+      .then((r) => r.data)
+  },
+}

--- a/admin-ui/src/components/invoices/RecordPaymentDialog.tsx
+++ b/admin-ui/src/components/invoices/RecordPaymentDialog.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react'
+import { CreditCard } from 'lucide-react'
+import { Button, Input, Select, Textarea } from '../ui'
+import { useRecordPayment } from '../../hooks/useInvoices'
+import { cn } from '../../utils'
+import toast from 'react-hot-toast'
+import type { PaymentMethod } from '../../types/contract'
+
+const PAYMENT_METHODS: { value: PaymentMethod; label: string }[] = [
+  { value: 'CASH', label: 'Cash' },
+  { value: 'BANK_TRANSFER', label: 'Bank Transfer' },
+  { value: 'CHECK', label: 'Check' },
+  { value: 'CREDIT_CARD', label: 'Credit Card' },
+  { value: 'INSTALLMENT', label: 'Installment' },
+]
+
+interface RecordPaymentDialogProps {
+  isOpen: boolean
+  invoiceId: string
+  onClose: () => void
+}
+
+export function RecordPaymentDialog({
+  isOpen,
+  invoiceId,
+  onClose,
+}: RecordPaymentDialogProps) {
+  const recordPaymentMutation = useRecordPayment()
+  const [paidDate, setPaidDate] = useState(new Date().toISOString().split('T')[0])
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('BANK_TRANSFER')
+  const [notes, setNotes] = useState('')
+  const [errors, setErrors] = useState<{ paidDate?: string }>({})
+
+  if (!isOpen) return null
+
+  function validate(): boolean {
+    const errs: { paidDate?: string } = {}
+    if (!paidDate) errs.paidDate = 'Payment date is required'
+    setErrors(errs)
+    return Object.keys(errs).length === 0
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+
+    try {
+      await recordPaymentMutation.mutateAsync({
+        id: invoiceId,
+        data: {
+          paidDate,
+          paymentMethod,
+          ...(notes.trim() ? { notes: notes.trim() } : {}),
+        },
+      })
+      toast.success('Payment recorded successfully')
+      setPaidDate(new Date().toISOString().split('T')[0])
+      setPaymentMethod('BANK_TRANSFER')
+      setNotes('')
+      onClose()
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'response' in err
+          ? String(
+              (err as { response?: { data?: { message?: string } } }).response?.data?.message ??
+                'Failed to record payment',
+            )
+          : 'Failed to record payment'
+      toast.error(message)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      {/* Panel */}
+      <div
+        className={cn(
+          'relative w-full max-w-md rounded-xl bg-white shadow-xl p-6',
+          'dark:bg-gray-800 dark:border dark:border-gray-700',
+        )}
+      >
+        <div className="flex items-center gap-3 mb-5">
+          <div className="shrink-0 rounded-full bg-green-100 dark:bg-green-900/30 p-2.5">
+            <CreditCard size={20} className="text-green-600 dark:text-green-400" />
+          </div>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Record Payment
+          </h3>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            label="Payment Date"
+            type="date"
+            required
+            value={paidDate}
+            onChange={(e) => {
+              setPaidDate(e.target.value)
+              setErrors({})
+            }}
+            error={errors.paidDate}
+          />
+
+          <Select
+            label="Payment Method"
+            required
+            options={PAYMENT_METHODS}
+            value={paymentMethod}
+            onChange={(e) => setPaymentMethod(e.target.value as PaymentMethod)}
+          />
+
+          <Textarea
+            label="Notes / Reference (Optional)"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="e.g. Bank transfer ref #12345"
+            rows={3}
+          />
+
+          <div className="flex justify-end gap-3 pt-2">
+            <Button
+              variant="secondary"
+              type="button"
+              onClick={onClose}
+              disabled={recordPaymentMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              loading={recordPaymentMutation.isPending}
+              leftIcon={<CreditCard size={16} />}
+            >
+              Record Payment
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/components/ui/ConfirmDialog.tsx
+++ b/admin-ui/src/components/ui/ConfirmDialog.tsx
@@ -5,7 +5,7 @@ import { cn } from '../../utils'
 interface ConfirmDialogProps {
   isOpen: boolean
   title: string
-  message: string
+  message: React.ReactNode
   confirmLabel?: string
   cancelLabel?: string
   variant?: 'danger' | 'primary'

--- a/admin-ui/src/hooks/useAgents.ts
+++ b/admin-ui/src/hooks/useAgents.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { agentsApi } from '../api/agents'
+
+export function useAgentsList(params?: { page?: number; limit?: number; search?: string }) {
+  return useQuery({
+    queryKey: ['agents', 'list', params],
+    queryFn: () => agentsApi.list(params),
+    staleTime: 60_000,
+  })
+}
+
+export function useAgentDetail(id: string) {
+  return useQuery({
+    queryKey: ['agents', 'detail', id],
+    queryFn: () => agentsApi.getById(id),
+    enabled: !!id,
+    staleTime: 60_000,
+  })
+}

--- a/admin-ui/src/hooks/useContracts.ts
+++ b/admin-ui/src/hooks/useContracts.ts
@@ -1,0 +1,111 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { contractsApi } from '../api/contracts'
+import type {
+  ContractFilter,
+  CreateContractPayload,
+  UpdateContractPayload,
+  ChangeContractStatusPayload,
+  GenerateInvoicesPayload,
+} from '../types/contract'
+
+const KEYS = {
+  all: ['contracts'] as const,
+  lists: () => [...KEYS.all, 'list'] as const,
+  list: (filter: ContractFilter) => [...KEYS.lists(), filter] as const,
+  details: () => [...KEYS.all, 'detail'] as const,
+  detail: (id: string) => [...KEYS.details(), id] as const,
+  stats: () => [...KEYS.all, 'stats'] as const,
+  expiring: (days: number) => [...KEYS.all, 'expiring', days] as const,
+  invoices: (id: string) => [...KEYS.all, 'invoices', id] as const,
+}
+
+export function useContractsList(filter: ContractFilter) {
+  return useQuery({
+    queryKey: KEYS.list(filter),
+    queryFn: () => contractsApi.list(filter),
+    staleTime: 30_000,
+  })
+}
+
+export function useContractDetail(id: string) {
+  return useQuery({
+    queryKey: KEYS.detail(id),
+    queryFn: () => contractsApi.getById(id),
+    enabled: !!id,
+    staleTime: 30_000,
+  })
+}
+
+export function useContractStats() {
+  return useQuery({
+    queryKey: KEYS.stats(),
+    queryFn: () => contractsApi.getStats(),
+    staleTime: 60_000,
+  })
+}
+
+export function useExpiringContracts(days = 30) {
+  return useQuery({
+    queryKey: KEYS.expiring(days),
+    queryFn: () => contractsApi.getExpiring(days),
+    staleTime: 60_000,
+  })
+}
+
+export function useContractInvoices(id: string) {
+  return useQuery({
+    queryKey: KEYS.invoices(id),
+    queryFn: () => contractsApi.getInvoices(id),
+    enabled: !!id,
+    staleTime: 30_000,
+  })
+}
+
+export function useCreateContract() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: CreateContractPayload) => contractsApi.create(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.stats() })
+    },
+  })
+}
+
+export function useUpdateContract() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateContractPayload }) =>
+      contractsApi.update(id, data),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.detail(id) })
+    },
+  })
+}
+
+export function useChangeContractStatus() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ChangeContractStatusPayload }) =>
+      contractsApi.changeStatus(id, data),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.detail(id) })
+      qc.invalidateQueries({ queryKey: KEYS.stats() })
+    },
+  })
+}
+
+export function useGenerateInvoices() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data?: GenerateInvoicesPayload }) =>
+      contractsApi.generateInvoices(id, data),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: KEYS.detail(id) })
+      qc.invalidateQueries({ queryKey: KEYS.invoices(id) })
+      qc.invalidateQueries({ queryKey: ['invoices'] })
+    },
+  })
+}

--- a/admin-ui/src/hooks/useInvoices.ts
+++ b/admin-ui/src/hooks/useInvoices.ts
@@ -1,0 +1,111 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { invoicesApi } from '../api/invoices'
+import type {
+  InvoiceFilter,
+  CreateInvoicePayload,
+  UpdateInvoicePayload,
+  RecordPaymentPayload,
+} from '../types/invoice'
+
+const KEYS = {
+  all: ['invoices'] as const,
+  lists: () => [...KEYS.all, 'list'] as const,
+  list: (filter: InvoiceFilter) => [...KEYS.lists(), filter] as const,
+  details: () => [...KEYS.all, 'detail'] as const,
+  detail: (id: string) => [...KEYS.details(), id] as const,
+  stats: () => [...KEYS.all, 'stats'] as const,
+  overdue: () => [...KEYS.all, 'overdue'] as const,
+  upcoming: (days: number) => [...KEYS.all, 'upcoming', days] as const,
+}
+
+export function useInvoicesList(filter: InvoiceFilter) {
+  return useQuery({
+    queryKey: KEYS.list(filter),
+    queryFn: () => invoicesApi.list(filter),
+    staleTime: 30_000,
+  })
+}
+
+export function useInvoiceDetail(id: string) {
+  return useQuery({
+    queryKey: KEYS.detail(id),
+    queryFn: () => invoicesApi.getById(id),
+    enabled: !!id,
+    staleTime: 30_000,
+  })
+}
+
+export function useInvoiceStats() {
+  return useQuery({
+    queryKey: KEYS.stats(),
+    queryFn: () => invoicesApi.getStats(),
+    staleTime: 60_000,
+  })
+}
+
+export function useOverdueInvoices() {
+  return useQuery({
+    queryKey: KEYS.overdue(),
+    queryFn: () => invoicesApi.getOverdue(),
+    staleTime: 60_000,
+  })
+}
+
+export function useUpcomingInvoices(days = 30) {
+  return useQuery({
+    queryKey: KEYS.upcoming(days),
+    queryFn: () => invoicesApi.getUpcoming(days),
+    staleTime: 60_000,
+  })
+}
+
+export function useCreateInvoice() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: CreateInvoicePayload) => invoicesApi.create(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.stats() })
+      qc.invalidateQueries({ queryKey: ['contracts'] })
+    },
+  })
+}
+
+export function useUpdateInvoice() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateInvoicePayload }) =>
+      invoicesApi.update(id, data),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.detail(id) })
+    },
+  })
+}
+
+export function useRecordPayment() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: RecordPaymentPayload }) =>
+      invoicesApi.recordPayment(id, data),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.detail(id) })
+      qc.invalidateQueries({ queryKey: KEYS.stats() })
+      qc.invalidateQueries({ queryKey: KEYS.overdue() })
+      qc.invalidateQueries({ queryKey: ['contracts'] })
+    },
+  })
+}
+
+export function useCancelInvoice() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => invoicesApi.cancel(id),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: KEYS.lists() })
+      qc.invalidateQueries({ queryKey: KEYS.detail(id) })
+      qc.invalidateQueries({ queryKey: KEYS.stats() })
+    },
+  })
+}

--- a/admin-ui/src/hooks/useReports.ts
+++ b/admin-ui/src/hooks/useReports.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+import { reportsApi } from '../api/reports'
+import type { RevenueReportParams, LeadConversionParams } from '../types/reports'
+
+export function useRevenueReport(params?: RevenueReportParams) {
+  return useQuery({
+    queryKey: ['reports', 'revenue', params],
+    queryFn: () => reportsApi.getRevenue(params),
+    staleTime: 120_000,
+  })
+}
+
+export function useLeadConversionReport(params?: LeadConversionParams) {
+  return useQuery({
+    queryKey: ['reports', 'lead-conversion', params],
+    queryFn: () => reportsApi.getLeadConversion(params),
+    staleTime: 120_000,
+  })
+}
+
+export function usePropertyReport() {
+  return useQuery({
+    queryKey: ['reports', 'properties'],
+    queryFn: () => reportsApi.getProperties(),
+    staleTime: 120_000,
+  })
+}

--- a/admin-ui/src/pages/agents/AgentDetailPage.tsx
+++ b/admin-ui/src/pages/agents/AgentDetailPage.tsx
@@ -1,0 +1,335 @@
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import {
+  ArrowLeft,
+  UserCog,
+  Building2,
+  Users,
+  FileText,
+  TrendingUp,
+  DollarSign,
+  CheckCircle,
+  XCircle,
+  Mail,
+  Calendar,
+} from 'lucide-react'
+import { Button, Skeleton } from '../../components/ui'
+import { ChartCard } from '../../components/dashboard'
+import { useAgentDetail } from '../../hooks/useAgents'
+import { getInitials, formatCurrency } from '../../utils'
+
+export default function AgentDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { data: agent, isLoading } = useAgentDetail(id ?? '')
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <Skeleton height="h-8" />
+        <Skeleton height="h-40" />
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <Skeleton height="h-64" />
+          <Skeleton height="h-64" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!agent) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20">
+        <UserCog size={48} className="text-gray-300 dark:text-gray-600" />
+        <p className="mt-4 text-gray-500 dark:text-gray-400">Agent not found</p>
+        <Button variant="secondary" className="mt-4" onClick={() => navigate('/agents')}>
+          Back to Agents
+        </Button>
+      </div>
+    )
+  }
+
+  const fullName =
+    agent.firstName || agent.lastName
+      ? `${agent.firstName ?? ''} ${agent.lastName ?? ''}`.trim()
+      : agent.email
+
+  const perf = agent.performance
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Back Link */}
+      <button
+        onClick={() => navigate('/agents')}
+        className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 w-fit"
+      >
+        <ArrowLeft size={16} />
+        Back to Agents
+      </button>
+
+      {/* Agent Header */}
+      <div className="flex flex-col gap-4 rounded-xl border border-gray-200 bg-white p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between dark:border-gray-700 dark:bg-gray-800">
+        <div className="flex items-center gap-4">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-indigo-100 text-lg font-bold text-indigo-600 dark:bg-indigo-900/40 dark:text-indigo-400">
+            {getInitials(fullName)}
+          </div>
+          <div>
+            <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{fullName}</h1>
+            <div className="mt-1 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+              <span className="flex items-center gap-1">
+                <Mail size={14} />
+                {agent.email}
+              </span>
+              <span className="flex items-center gap-1">
+                <Calendar size={14} />
+                Joined {new Date(agent.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+              </span>
+            </div>
+          </div>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium w-fit ${
+            agent.isActive
+              ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+              : 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+          }`}
+        >
+          {agent.isActive ? <CheckCircle size={14} /> : <XCircle size={14} />}
+          {agent.isActive ? 'Active' : 'Inactive'}
+        </span>
+      </div>
+
+      {/* Performance Stats */}
+      {perf && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex items-center gap-2">
+              <div className="rounded-lg bg-indigo-50 p-2 dark:bg-indigo-900/30">
+                <FileText size={18} className="text-indigo-600 dark:text-indigo-400" />
+              </div>
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Total Leads</p>
+            </div>
+            <p className="mt-2 text-2xl font-bold text-gray-900 dark:text-gray-100">{perf.totalLeads}</p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex items-center gap-2">
+              <div className="rounded-lg bg-green-50 p-2 dark:bg-green-900/30">
+                <CheckCircle size={18} className="text-green-600 dark:text-green-400" />
+              </div>
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Leads Won</p>
+            </div>
+            <p className="mt-2 text-2xl font-bold text-green-600 dark:text-green-400">{perf.leadsWon}</p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex items-center gap-2">
+              <div className="rounded-lg bg-sky-50 p-2 dark:bg-sky-900/30">
+                <DollarSign size={18} className="text-sky-600 dark:text-sky-400" />
+              </div>
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Revenue</p>
+            </div>
+            <p className="mt-2 text-2xl font-bold text-gray-900 dark:text-gray-100">
+              {formatCurrency(perf.revenue)}
+            </p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex items-center gap-2">
+              <div className="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
+                <TrendingUp size={18} className="text-amber-600 dark:text-amber-400" />
+              </div>
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Conversion Rate</p>
+            </div>
+            <p className="mt-2 text-2xl font-bold text-gray-900 dark:text-gray-100">{perf.conversionRate}%</p>
+          </div>
+        </div>
+      )}
+
+      {/* Assigned Properties */}
+      <ChartCard
+        title="Assigned Properties"
+        subtitle={`${agent.assignedProperties?.length ?? 0} properties`}
+        action={
+          <div className="rounded-lg bg-indigo-50 p-2 dark:bg-indigo-900/30">
+            <Building2 size={16} className="text-indigo-600 dark:text-indigo-400" />
+          </div>
+        }
+      >
+        {agent.assignedProperties?.length ? (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 text-xs font-medium uppercase text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                  <th className="pb-3 pr-4">Title</th>
+                  <th className="pb-3 pr-4">Type</th>
+                  <th className="pb-3 pr-4">Status</th>
+                  <th className="pb-3 text-right">Price</th>
+                </tr>
+              </thead>
+              <tbody>
+                {agent.assignedProperties.map((prop) => (
+                  <tr
+                    key={prop.id}
+                    className="border-b border-gray-100 last:border-0 dark:border-gray-700/50"
+                  >
+                    <td className="py-2.5 pr-4">
+                      <Link
+                        to={`/properties/${prop.id}`}
+                        className="font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                      >
+                        {prop.title}
+                      </Link>
+                    </td>
+                    <td className="py-2.5 pr-4 text-gray-600 dark:text-gray-400">{prop.type}</td>
+                    <td className="py-2.5 pr-4">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                          prop.status === 'AVAILABLE'
+                            ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                            : prop.status === 'SOLD'
+                              ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400'
+                              : 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+                        }`}
+                      >
+                        {prop.status}
+                      </span>
+                    </td>
+                    <td className="py-2.5 text-right font-medium text-gray-800 dark:text-gray-200">
+                      {formatCurrency(prop.price)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="py-8 text-center text-sm text-gray-400">No assigned properties</p>
+        )}
+      </ChartCard>
+
+      {/* Assigned Clients */}
+      <ChartCard
+        title="Assigned Clients"
+        subtitle={`${agent.assignedClients?.length ?? 0} clients`}
+        action={
+          <div className="rounded-lg bg-green-50 p-2 dark:bg-green-900/30">
+            <Users size={16} className="text-green-600 dark:text-green-400" />
+          </div>
+        }
+      >
+        {agent.assignedClients?.length ? (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 text-xs font-medium uppercase text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                  <th className="pb-3 pr-4">Name</th>
+                  <th className="pb-3 pr-4">Email</th>
+                  <th className="pb-3">Phone</th>
+                </tr>
+              </thead>
+              <tbody>
+                {agent.assignedClients.map((client) => (
+                  <tr
+                    key={client.id}
+                    className="border-b border-gray-100 last:border-0 dark:border-gray-700/50"
+                  >
+                    <td className="py-2.5 pr-4">
+                      <Link
+                        to={`/clients/${client.id}`}
+                        className="font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                      >
+                        {client.firstName} {client.lastName}
+                      </Link>
+                    </td>
+                    <td className="py-2.5 pr-4 text-gray-600 dark:text-gray-400">{client.email}</td>
+                    <td className="py-2.5 text-gray-600 dark:text-gray-400">{client.phone ?? '--'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="py-8 text-center text-sm text-gray-400">No assigned clients</p>
+        )}
+      </ChartCard>
+
+      {/* Assigned Leads */}
+      <ChartCard
+        title="Assigned Leads"
+        subtitle={`${agent.assignedLeads?.length ?? 0} leads`}
+        action={
+          <div className="rounded-lg bg-amber-50 p-2 dark:bg-amber-900/30">
+            <FileText size={16} className="text-amber-600 dark:text-amber-400" />
+          </div>
+        }
+      >
+        {agent.assignedLeads?.length ? (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 text-xs font-medium uppercase text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                  <th className="pb-3 pr-4">Title</th>
+                  <th className="pb-3 pr-4">Status</th>
+                  <th className="pb-3 pr-4">Priority</th>
+                  <th className="pb-3 pr-4">Source</th>
+                  <th className="pb-3">Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {agent.assignedLeads.map((lead) => (
+                  <tr
+                    key={lead.id}
+                    className="border-b border-gray-100 last:border-0 dark:border-gray-700/50"
+                  >
+                    <td className="py-2.5 pr-4">
+                      <Link
+                        to={`/leads/${lead.id}`}
+                        className="font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                      >
+                        {lead.title}
+                      </Link>
+                    </td>
+                    <td className="py-2.5 pr-4">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                          lead.status === 'WON'
+                            ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                            : lead.status === 'LOST'
+                              ? 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                              : 'bg-sky-50 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400'
+                        }`}
+                      >
+                        {lead.status}
+                      </span>
+                    </td>
+                    <td className="py-2.5 pr-4">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                          lead.priority === 'HIGH'
+                            ? 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                            : lead.priority === 'MEDIUM'
+                              ? 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+                              : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+                        }`}
+                      >
+                        {lead.priority}
+                      </span>
+                    </td>
+                    <td className="py-2.5 pr-4 text-gray-600 dark:text-gray-400">
+                      {lead.source ?? '--'}
+                    </td>
+                    <td className="py-2.5 text-gray-600 dark:text-gray-400">
+                      {new Date(lead.createdAt).toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      })}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="py-8 text-center text-sm text-gray-400">No assigned leads</p>
+        )}
+      </ChartCard>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/agents/AgentsListPage.tsx
+++ b/admin-ui/src/pages/agents/AgentsListPage.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { UserCog, Search, Users, Building2, FileText, CheckCircle, XCircle } from 'lucide-react'
+import { Skeleton } from '../../components/ui'
+import { useAgentsList } from '../../hooks/useAgents'
+import { getInitials } from '../../utils'
+
+export default function AgentsListPage() {
+  const navigate = useNavigate()
+  const [search, setSearch] = useState('')
+  const [page, setPage] = useState(1)
+  const limit = 10
+
+  const { data, isLoading } = useAgentsList({ page, limit, search: search || undefined })
+
+  const agents = data?.data ?? []
+  const total = data?.total ?? 0
+  const totalPages = data?.totalPages ?? 1
+
+  function fullName(agent: { firstName: string | null; lastName: string | null; email: string }) {
+    if (agent.firstName || agent.lastName) {
+      return `${agent.firstName ?? ''} ${agent.lastName ?? ''}`.trim()
+    }
+    return agent.email
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <UserCog size={24} className="text-indigo-500" />
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Agents</h1>
+            <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+              Manage agents and view workload overview
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="relative max-w-md">
+        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+        <input
+          type="text"
+          placeholder="Search agents by name or email..."
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value)
+            setPage(1)
+          }}
+          className="w-full rounded-lg border border-gray-300 bg-white py-2 pl-10 pr-4 text-sm text-gray-800 placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:placeholder-gray-500"
+        />
+      </div>
+
+      {/* Agent Cards */}
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+            >
+              <Skeleton height="h-24" />
+            </div>
+          ))}
+        </div>
+      ) : agents.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 bg-white py-16 dark:border-gray-700 dark:bg-gray-800">
+          <UserCog size={40} className="text-gray-300 dark:text-gray-600" />
+          <p className="mt-3 text-gray-500 dark:text-gray-400">No agents found</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {agents.map((agent) => {
+            const name = fullName(agent)
+            const counts = agent._count
+            return (
+              <div
+                key={agent.id}
+                onClick={() => navigate(`/agents/${agent.id}`)}
+                className="cursor-pointer rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-indigo-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-indigo-600"
+              >
+                {/* Agent Header */}
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-100 text-sm font-semibold text-indigo-600 dark:bg-indigo-900/40 dark:text-indigo-400">
+                      {getInitials(name)}
+                    </div>
+                    <div>
+                      <p className="font-semibold text-gray-800 dark:text-gray-200">{name}</p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">{agent.email}</p>
+                    </div>
+                  </div>
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
+                      agent.isActive
+                        ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                        : 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                    }`}
+                  >
+                    {agent.isActive ? <CheckCircle size={12} /> : <XCircle size={12} />}
+                    {agent.isActive ? 'Active' : 'Inactive'}
+                  </span>
+                </div>
+
+                {/* Workload Stats */}
+                {counts && (
+                  <div className="mt-4 grid grid-cols-3 gap-3">
+                    <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-700/50">
+                      <Building2 size={14} className="text-indigo-500" />
+                      <div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">Properties</p>
+                        <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                          {counts.assignedProperties}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-700/50">
+                      <Users size={14} className="text-green-500" />
+                      <div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">Clients</p>
+                        <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                          {counts.assignedClients}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-700/50">
+                      <FileText size={14} className="text-amber-500" />
+                      <div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">Leads</p>
+                        <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                          {counts.assignedLeads}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Last Login */}
+                <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">
+                  {agent.lastLoginAt
+                    ? `Last login: ${new Date(agent.lastLoginAt).toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      })}`
+                    : 'Never logged in'}
+                </p>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
+          <p>
+            Showing {(page - 1) * limit + 1}–{Math.min(page * limit, total)} of {total} agents
+          </p>
+          <div className="flex gap-2">
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+              className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700"
+            >
+              Previous
+            </button>
+            <button
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+              className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/admin-ui/src/pages/contracts/ContractDetailPage.tsx
+++ b/admin-ui/src/pages/contracts/ContractDetailPage.tsx
@@ -1,0 +1,413 @@
+import { useState } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import {
+  ArrowLeft,
+  Edit,
+  FileText,
+  Calendar,
+  DollarSign,
+  User,
+  Home,
+  Receipt,
+  Zap,
+  AlertCircle,
+} from 'lucide-react'
+import { Button, LoadingSpinner, Select } from '../../components/ui'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import {
+  useContractDetail,
+  useChangeContractStatus,
+  useGenerateInvoices,
+} from '../../hooks/useContracts'
+import { formatDate, formatCurrency } from '../../utils'
+import toast from 'react-hot-toast'
+import type { ContractStatus, PaymentMethod } from '../../types/contract'
+
+const statusBadge: Record<string, string> = {
+  DRAFT: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  ACTIVE: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  COMPLETED: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  CANCELLED: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  EXPIRED: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+}
+
+const invoiceStatusBadge: Record<string, string> = {
+  PENDING: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  PAID: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  OVERDUE: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  CANCELLED: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  REFUNDED: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+}
+
+const STATUS_OPTIONS: { value: ContractStatus; label: string }[] = [
+  { value: 'DRAFT', label: 'Draft' },
+  { value: 'ACTIVE', label: 'Active' },
+  { value: 'COMPLETED', label: 'Completed' },
+  { value: 'CANCELLED', label: 'Cancelled' },
+  { value: 'EXPIRED', label: 'Expired' },
+]
+
+const PAYMENT_METHODS: { value: PaymentMethod; label: string }[] = [
+  { value: 'CASH', label: 'Cash' },
+  { value: 'BANK_TRANSFER', label: 'Bank Transfer' },
+  { value: 'CHECK', label: 'Check' },
+  { value: 'CREDIT_CARD', label: 'Credit Card' },
+  { value: 'INSTALLMENT', label: 'Installment' },
+]
+
+export default function ContractDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { data: contract, isLoading, isError } = useContractDetail(id!)
+  const changeStatusMutation = useChangeContractStatus()
+  const generateInvoicesMutation = useGenerateInvoices()
+
+  const [statusDialogOpen, setStatusDialogOpen] = useState(false)
+  const [newStatus, setNewStatus] = useState<ContractStatus>('ACTIVE')
+  const [generateDialogOpen, setGenerateDialogOpen] = useState(false)
+  const [generatePaymentMethod, setGeneratePaymentMethod] = useState<PaymentMethod>('BANK_TRANSFER')
+
+  if (isLoading) return <LoadingSpinner message="Loading contract..." />
+  if (isError || !contract) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16">
+        <p className="text-gray-500">Contract not found.</p>
+        <Button variant="secondary" onClick={() => navigate('/contracts')}>
+          Back to Contracts
+        </Button>
+      </div>
+    )
+  }
+
+  async function handleChangeStatus() {
+    try {
+      await changeStatusMutation.mutateAsync({ id: id!, data: { status: newStatus } })
+      toast.success(`Status changed to ${newStatus}`)
+      setStatusDialogOpen(false)
+    } catch {
+      toast.error('Failed to change status')
+    }
+  }
+
+  async function handleGenerateInvoices() {
+    try {
+      const invoices = await generateInvoicesMutation.mutateAsync({
+        id: id!,
+        data: { paymentMethod: generatePaymentMethod },
+      })
+      toast.success(`${invoices.length} invoice(s) generated`)
+      setGenerateDialogOpen(false)
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'response' in err
+          ? String((err as { response?: { data?: { message?: string } } }).response?.data?.message ?? 'Failed to generate invoices')
+          : 'Failed to generate invoices'
+      toast.error(message)
+    }
+  }
+
+  const paidAmount = contract.invoices
+    ?.filter((inv) => inv.status === 'PAID')
+    .reduce((sum, inv) => sum + inv.amount, 0) ?? 0
+  const pendingAmount = contract.invoices
+    ?.filter((inv) => inv.status === 'PENDING' || inv.status === 'OVERDUE')
+    .reduce((sum, inv) => sum + inv.amount, 0) ?? 0
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate('/contracts')}
+            className="rounded-lg p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800"
+          >
+            <ArrowLeft size={20} />
+          </button>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              {contract.type} Contract
+            </h1>
+            <div className="flex items-center gap-2 mt-0.5">
+              <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${statusBadge[contract.status]}`}>
+                {contract.status}
+              </span>
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                Created {formatDate(contract.createdAt)}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              setNewStatus(contract.status)
+              setStatusDialogOpen(true)
+            }}
+          >
+            Change Status
+          </Button>
+          {contract.status === 'ACTIVE' && (
+            <Button
+              variant="secondary"
+              size="sm"
+              leftIcon={<Zap size={14} />}
+              onClick={() => setGenerateDialogOpen(true)}
+            >
+              Generate Invoices
+            </Button>
+          )}
+          <Button
+            leftIcon={<Edit size={16} />}
+            onClick={() => navigate(`/contracts/${id}/edit`)}
+          >
+            Edit
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Contract Info */}
+        <div className="lg:col-span-1 space-y-6">
+          {/* Details Card */}
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
+              <FileText size={18} className="text-indigo-500" /> Contract Details
+            </h2>
+            <dl className="space-y-3 text-sm">
+              <div className="flex justify-between">
+                <dt className="text-gray-500">Type</dt>
+                <dd className="font-medium text-gray-900 dark:text-gray-100">{contract.type}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-gray-500">Total Amount</dt>
+                <dd className="font-medium text-gray-900 dark:text-gray-100">
+                  {formatCurrency(contract.totalAmount)}
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-gray-500">Start Date</dt>
+                <dd className="text-gray-700 dark:text-gray-300">{formatDate(contract.startDate)}</dd>
+              </div>
+              {contract.endDate && (
+                <div className="flex justify-between">
+                  <dt className="text-gray-500">End Date</dt>
+                  <dd className="text-gray-700 dark:text-gray-300">{formatDate(contract.endDate)}</dd>
+                </div>
+              )}
+              {contract.paymentTerms && (
+                <div className="pt-2 border-t border-gray-100 dark:border-gray-700">
+                  <dt className="text-xs font-medium text-gray-500 mb-1">Payment Terms</dt>
+                  <dd className="text-gray-700 dark:text-gray-300 text-xs">
+                    {contract.paymentTerms.installments && (
+                      <span>{String(contract.paymentTerms.installments)} installments</span>
+                    )}
+                    {contract.paymentTerms.frequency && (
+                      <span> ({String(contract.paymentTerms.frequency)})</span>
+                    )}
+                  </dd>
+                </div>
+              )}
+              {contract.notes && (
+                <div className="pt-2 border-t border-gray-100 dark:border-gray-700">
+                  <dt className="text-xs font-medium text-gray-500 mb-1">Notes</dt>
+                  <dd className="text-gray-700 dark:text-gray-300 whitespace-pre-line">{contract.notes}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+          {/* Payment Summary */}
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
+              <DollarSign size={18} className="text-green-500" /> Payment Summary
+            </h2>
+            <div className="space-y-3">
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-500">Total</span>
+                <span className="font-semibold text-gray-900 dark:text-gray-100">
+                  {formatCurrency(contract.totalAmount)}
+                </span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-green-600">Paid</span>
+                <span className="font-medium text-green-600">{formatCurrency(paidAmount)}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-amber-600">Pending</span>
+                <span className="font-medium text-amber-600">{formatCurrency(pendingAmount)}</span>
+              </div>
+              <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 mt-2">
+                <div
+                  className="bg-green-500 h-2 rounded-full transition-all"
+                  style={{
+                    width: `${contract.totalAmount > 0 ? Math.min((paidAmount / contract.totalAmount) * 100, 100) : 0}%`,
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Property Card */}
+          {contract.property && (
+            <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2">
+                <Home size={18} className="text-indigo-500" /> Property
+              </h2>
+              <Link
+                to={`/properties/${contract.property.id}`}
+                className="block rounded-lg border border-gray-100 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+              >
+                <p className="font-medium text-gray-900 dark:text-gray-100">{contract.property.title}</p>
+                {contract.property.address && (
+                  <p className="text-xs text-gray-500 mt-0.5">{contract.property.address}</p>
+                )}
+              </Link>
+            </div>
+          )}
+
+          {/* Client Card */}
+          {contract.client && (
+            <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2">
+                <User size={18} className="text-indigo-500" /> Client
+              </h2>
+              <Link
+                to={`/clients/${contract.client.id}`}
+                className="block rounded-lg border border-gray-100 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+              >
+                <p className="font-medium text-gray-900 dark:text-gray-100">
+                  {contract.client.firstName} {contract.client.lastName}
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">{contract.client.phone}</p>
+                {contract.client.email && (
+                  <p className="text-xs text-gray-500">{contract.client.email}</p>
+                )}
+              </Link>
+            </div>
+          )}
+
+          {/* Document */}
+          {contract.documentUrl && (
+            <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2">
+                <FileText size={18} className="text-indigo-500" /> Document
+              </h2>
+              <a
+                href={contract.documentUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline break-all"
+              >
+                {contract.documentUrl}
+              </a>
+            </div>
+          )}
+        </div>
+
+        {/* Invoices */}
+        <div className="lg:col-span-2">
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+                <Receipt size={18} className="text-indigo-500" /> Invoices ({contract.invoices?.length ?? 0})
+              </h2>
+            </div>
+            {contract.invoices && contract.invoices.length > 0 ? (
+              <div className="space-y-2">
+                {contract.invoices.map((invoice) => (
+                  <Link
+                    key={invoice.id}
+                    to={`/invoices/${invoice.id}`}
+                    className="flex items-center justify-between rounded-lg border border-gray-100 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${invoiceStatusBadge[invoice.status] ?? ''}`}>
+                        {invoice.status}
+                      </span>
+                      <span className="text-sm text-gray-700 dark:text-gray-300">
+                        Due {formatDate(invoice.dueDate)}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="font-medium text-gray-900 dark:text-gray-100">
+                        {formatCurrency(invoice.amount)}
+                      </span>
+                      {invoice.paidDate && (
+                        <span className="text-xs text-green-600">
+                          Paid {formatDate(invoice.paidDate)}
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center gap-3 py-8 text-center">
+                <AlertCircle size={32} className="text-gray-300" />
+                <p className="text-sm text-gray-400">No invoices yet.</p>
+                {contract.status === 'ACTIVE' && (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    leftIcon={<Zap size={14} />}
+                    onClick={() => setGenerateDialogOpen(true)}
+                  >
+                    Generate Invoices
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Change Status Dialog */}
+      <ConfirmDialog
+        isOpen={statusDialogOpen}
+        title="Change Contract Status"
+        message={
+          <div className="space-y-3">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Select the new status for this contract.
+            </p>
+            <Select
+              options={STATUS_OPTIONS}
+              value={newStatus}
+              onChange={(e) => setNewStatus(e.target.value as ContractStatus)}
+            />
+          </div>
+        }
+        confirmLabel="Update Status"
+        onConfirm={handleChangeStatus}
+        onCancel={() => setStatusDialogOpen(false)}
+        loading={changeStatusMutation.isPending}
+      />
+
+      {/* Generate Invoices Dialog */}
+      <ConfirmDialog
+        isOpen={generateDialogOpen}
+        title="Generate Invoices"
+        message={
+          <div className="space-y-3">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Auto-generate invoices based on payment terms. Select the default payment method.
+            </p>
+            <Select
+              label="Payment Method"
+              options={PAYMENT_METHODS}
+              value={generatePaymentMethod}
+              onChange={(e) => setGeneratePaymentMethod(e.target.value as PaymentMethod)}
+            />
+          </div>
+        }
+        confirmLabel="Generate"
+        onConfirm={handleGenerateInvoices}
+        onCancel={() => setGenerateDialogOpen(false)}
+        loading={generateInvoicesMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/admin-ui/src/pages/contracts/ContractFormPage.tsx
+++ b/admin-ui/src/pages/contracts/ContractFormPage.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeft, Save } from 'lucide-react'
+import { Button, Input, Select, Textarea, LoadingSpinner } from '../../components/ui'
+import {
+  useContractDetail,
+  useCreateContract,
+  useUpdateContract,
+} from '../../hooks/useContracts'
+import { useClientsList } from '../../hooks/useClients'
+import toast from 'react-hot-toast'
+import type { ContractType, CreateContractPayload } from '../../types/contract'
+
+const CONTRACT_TYPES: { value: ContractType; label: string }[] = [
+  { value: 'SALE', label: 'Sale' },
+  { value: 'RENT', label: 'Rent' },
+  { value: 'LEASE', label: 'Lease' },
+]
+
+interface FormState {
+  type: ContractType
+  propertyId: string
+  clientId: string
+  agentId: string
+  startDate: string
+  endDate: string
+  totalAmount: string
+  installments: string
+  frequency: string
+  documentUrl: string
+  notes: string
+}
+
+const INITIAL: FormState = {
+  type: 'SALE',
+  propertyId: '',
+  clientId: '',
+  agentId: '',
+  startDate: '',
+  endDate: '',
+  totalAmount: '',
+  installments: '',
+  frequency: 'monthly',
+  documentUrl: '',
+  notes: '',
+}
+
+const FREQUENCY_OPTIONS = [
+  { value: 'monthly', label: 'Monthly' },
+  { value: 'quarterly', label: 'Quarterly' },
+  { value: 'semi-annual', label: 'Semi-Annual' },
+  { value: 'annual', label: 'Annual' },
+  { value: 'one-time', label: 'One-Time' },
+]
+
+export default function ContractFormPage() {
+  const { id } = useParams<{ id: string }>()
+  const isEdit = !!id
+  const navigate = useNavigate()
+  const [form, setForm] = useState<FormState>(INITIAL)
+  const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({})
+
+  const { data: existing, isLoading: loadingExisting } = useContractDetail(id ?? '')
+  const createMutation = useCreateContract()
+  const updateMutation = useUpdateContract()
+
+  // Fetch clients for the dropdown
+  const { data: clientsData } = useClientsList({ page: 1, pageSize: 200 })
+  const clientOptions = (clientsData?.data ?? []).map((c) => ({
+    value: c.id,
+    label: `${c.firstName} ${c.lastName}`,
+  }))
+
+  useEffect(() => {
+    if (existing && isEdit) {
+      setForm({
+        type: existing.type,
+        propertyId: existing.propertyId,
+        clientId: existing.clientId,
+        agentId: existing.agentId ?? '',
+        startDate: existing.startDate ? existing.startDate.split('T')[0] : '',
+        endDate: existing.endDate ? existing.endDate.split('T')[0] : '',
+        totalAmount: String(existing.totalAmount),
+        installments: existing.paymentTerms?.installments ? String(existing.paymentTerms.installments) : '',
+        frequency: existing.paymentTerms?.frequency ? String(existing.paymentTerms.frequency) : 'monthly',
+        documentUrl: existing.documentUrl ?? '',
+        notes: existing.notes ?? '',
+      })
+    }
+  }, [existing, isEdit])
+
+  function set<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => ({ ...f, [key]: value }))
+    setErrors((e) => ({ ...e, [key]: undefined }))
+  }
+
+  function validate(): boolean {
+    const errs: Partial<Record<keyof FormState, string>> = {}
+    if (!form.propertyId.trim()) errs.propertyId = 'Property ID is required'
+    if (!form.clientId.trim()) errs.clientId = 'Client is required'
+    if (!form.startDate) errs.startDate = 'Start date is required'
+    if (!form.totalAmount || Number(form.totalAmount) <= 0) errs.totalAmount = 'Enter a valid amount'
+    if (form.endDate && form.startDate && form.endDate < form.startDate)
+      errs.endDate = 'End date must be after start date'
+    setErrors(errs)
+    return Object.keys(errs).length === 0
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+
+    const paymentTerms: Record<string, unknown> = {}
+    if (form.installments) paymentTerms.installments = Number(form.installments)
+    if (form.frequency) paymentTerms.frequency = form.frequency
+
+    const payload: CreateContractPayload = {
+      type: form.type,
+      propertyId: form.propertyId.trim(),
+      clientId: form.clientId.trim(),
+      startDate: form.startDate,
+      totalAmount: Number(form.totalAmount),
+      ...(form.agentId ? { agentId: form.agentId.trim() } : {}),
+      ...(form.endDate ? { endDate: form.endDate } : {}),
+      ...(Object.keys(paymentTerms).length > 0 ? { paymentTerms } : {}),
+      ...(form.documentUrl ? { documentUrl: form.documentUrl.trim() } : {}),
+      ...(form.notes ? { notes: form.notes.trim() } : {}),
+    }
+
+    try {
+      if (isEdit) {
+        await updateMutation.mutateAsync({ id: id!, data: payload })
+        toast.success('Contract updated')
+        navigate(`/contracts/${id}`)
+      } else {
+        const created = await createMutation.mutateAsync(payload)
+        toast.success('Contract created')
+        navigate(`/contracts/${created.id}`)
+      }
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'response' in err
+          ? String((err as { response?: { data?: { message?: string } } }).response?.data?.message ?? 'Something went wrong')
+          : 'Something went wrong'
+      toast.error(message)
+    }
+  }
+
+  if (isEdit && loadingExisting) return <LoadingSpinner message="Loading contract..." />
+
+  const isPending = createMutation.isPending || updateMutation.isPending
+
+  return (
+    <div className="flex flex-col gap-6 max-w-2xl">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => navigate(isEdit ? `/contracts/${id}` : '/contracts')}
+          className="rounded-lg p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800"
+        >
+          <ArrowLeft size={20} />
+        </button>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          {isEdit ? 'Edit Contract' : 'New Contract'}
+        </h1>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 space-y-5"
+      >
+        {/* Type */}
+        <Select
+          label="Contract Type"
+          required
+          options={CONTRACT_TYPES}
+          value={form.type}
+          onChange={(e) => set('type', e.target.value as ContractType)}
+        />
+
+        {/* Property & Client */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Input
+            label="Property ID"
+            required
+            value={form.propertyId}
+            onChange={(e) => set('propertyId', e.target.value)}
+            error={errors.propertyId}
+            placeholder="UUID of the property"
+          />
+          <Select
+            label="Client"
+            required
+            options={[{ value: '', label: 'Select a client...' }, ...clientOptions]}
+            value={form.clientId}
+            onChange={(e) => set('clientId', e.target.value)}
+            error={errors.clientId}
+          />
+        </div>
+
+        {/* Agent */}
+        <Input
+          label="Agent ID (Optional)"
+          value={form.agentId}
+          onChange={(e) => set('agentId', e.target.value)}
+          placeholder="UUID of the assigned agent"
+        />
+
+        {/* Dates */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Input
+            label="Start Date"
+            type="date"
+            required
+            value={form.startDate}
+            onChange={(e) => set('startDate', e.target.value)}
+            error={errors.startDate}
+          />
+          <Input
+            label="End Date"
+            type="date"
+            value={form.endDate}
+            onChange={(e) => set('endDate', e.target.value)}
+            error={errors.endDate}
+          />
+        </div>
+
+        {/* Amount */}
+        <Input
+          label="Total Amount"
+          type="number"
+          required
+          value={form.totalAmount}
+          onChange={(e) => set('totalAmount', e.target.value)}
+          error={errors.totalAmount}
+          placeholder="0.00"
+        />
+
+        {/* Payment Terms */}
+        <div className="border-t border-gray-100 dark:border-gray-700 pt-4">
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+            Payment Terms (Optional)
+          </h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Input
+              label="Number of Installments"
+              type="number"
+              value={form.installments}
+              onChange={(e) => set('installments', e.target.value)}
+              placeholder="e.g. 12"
+            />
+            <Select
+              label="Payment Frequency"
+              options={FREQUENCY_OPTIONS}
+              value={form.frequency}
+              onChange={(e) => set('frequency', e.target.value)}
+            />
+          </div>
+        </div>
+
+        {/* Document URL */}
+        <Input
+          label="Document URL (Optional)"
+          value={form.documentUrl}
+          onChange={(e) => set('documentUrl', e.target.value)}
+          placeholder="https://..."
+        />
+
+        {/* Notes */}
+        <Textarea
+          label="Notes"
+          value={form.notes}
+          onChange={(e) => set('notes', e.target.value)}
+          placeholder="Any additional information..."
+        />
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3 pt-2">
+          <Button
+            variant="secondary"
+            type="button"
+            onClick={() => navigate(isEdit ? `/contracts/${id}` : '/contracts')}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" loading={isPending} leftIcon={<Save size={16} />}>
+            {isEdit ? 'Update Contract' : 'Create Contract'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/contracts/ContractsListPage.tsx
+++ b/admin-ui/src/pages/contracts/ContractsListPage.tsx
@@ -1,0 +1,239 @@
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { FileText, Plus, AlertTriangle, DollarSign, CheckCircle } from 'lucide-react'
+import { Button, DataTable, SearchBar, Select, StatsCard } from '../../components/ui'
+import { useContractsList, useContractStats } from '../../hooks/useContracts'
+import { formatDate, formatCurrency } from '../../utils'
+import type { ContractType, ContractStatus, ContractFilter } from '../../types/contract'
+import type { Column } from '../../types'
+
+const CONTRACT_TYPES: { value: ContractType; label: string }[] = [
+  { value: 'SALE', label: 'Sale' },
+  { value: 'RENT', label: 'Rent' },
+  { value: 'LEASE', label: 'Lease' },
+]
+
+const CONTRACT_STATUSES: { value: ContractStatus; label: string }[] = [
+  { value: 'DRAFT', label: 'Draft' },
+  { value: 'ACTIVE', label: 'Active' },
+  { value: 'COMPLETED', label: 'Completed' },
+  { value: 'CANCELLED', label: 'Cancelled' },
+  { value: 'EXPIRED', label: 'Expired' },
+]
+
+const statusBadge: Record<string, string> = {
+  DRAFT: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  ACTIVE: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  COMPLETED: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  CANCELLED: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  EXPIRED: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+}
+
+const typeBadge: Record<string, string> = {
+  SALE: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+  RENT: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  LEASE: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400',
+}
+
+export default function ContractsListPage() {
+  const navigate = useNavigate()
+  const [filter, setFilter] = useState<ContractFilter>({
+    page: 1,
+    pageSize: 10,
+    sortBy: 'createdAt',
+    sortOrder: 'desc',
+  })
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
+
+  const effectiveFilter: ContractFilter = {
+    ...filter,
+    ...(dateFrom ? { dateFrom } : {}),
+    ...(dateTo ? { dateTo } : {}),
+  }
+
+  const { data, isLoading } = useContractsList(effectiveFilter)
+  const { data: stats } = useContractStats()
+
+  const handleDateFilter = useCallback(() => {
+    setFilter((f) => ({ ...f, page: 1 }))
+  }, [])
+
+  const columns: Column[] = [
+    {
+      key: 'property',
+      header: 'Property',
+      render: (_v, row) => (
+        <div className="flex flex-col">
+          <span className="font-medium text-gray-900 dark:text-gray-100">
+            {(row.property as { title?: string })?.title ?? 'N/A'}
+          </span>
+          <span className="text-xs text-gray-500">
+            {(row.client as { firstName?: string; lastName?: string })
+              ? `${(row.client as { firstName: string }).firstName} ${(row.client as { lastName: string }).lastName}`
+              : 'N/A'}
+          </span>
+        </div>
+      ),
+    },
+    {
+      key: 'type',
+      header: 'Type',
+      sortable: true,
+      render: (v) => (
+        <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${typeBadge[String(v)] ?? ''}`}>
+          {String(v)}
+        </span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      sortable: true,
+      render: (v) => (
+        <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${statusBadge[String(v)] ?? ''}`}>
+          {String(v)}
+        </span>
+      ),
+    },
+    {
+      key: 'totalAmount',
+      header: 'Amount',
+      sortable: true,
+      render: (v) => (
+        <span className="font-medium text-gray-900 dark:text-gray-100">
+          {formatCurrency(Number(v))}
+        </span>
+      ),
+    },
+    {
+      key: 'startDate',
+      header: 'Start Date',
+      sortable: true,
+      render: (v) => <span className="text-gray-500 text-xs">{formatDate(String(v))}</span>,
+    },
+    {
+      key: 'endDate',
+      header: 'End Date',
+      render: (v) => (
+        <span className="text-gray-500 text-xs">{v ? formatDate(String(v)) : '-'}</span>
+      ),
+    },
+    {
+      key: 'createdAt',
+      header: 'Created',
+      sortable: true,
+      render: (v) => <span className="text-gray-500 text-xs">{formatDate(String(v))}</span>,
+    },
+  ]
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <FileText size={24} className="text-indigo-500" />
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Contracts</h1>
+        </div>
+        <Button leftIcon={<Plus size={16} />} onClick={() => navigate('/contracts/new')}>
+          New Contract
+        </Button>
+      </div>
+
+      {/* Stats */}
+      {stats && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <StatsCard title="Total Contracts" value={stats.total} icon={FileText} color="indigo" />
+          <StatsCard title="Active" value={stats.byStatus?.ACTIVE ?? 0} icon={CheckCircle} color="green" />
+          <StatsCard title="Draft" value={stats.byStatus?.DRAFT ?? 0} icon={AlertTriangle} color="amber" />
+          <StatsCard
+            title="Total Value"
+            value={formatCurrency(stats.totalValue ?? 0)}
+            icon={DollarSign}
+            color="sky"
+          />
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-end gap-3">
+        <Select
+          options={[{ value: '', label: 'All Types' }, ...CONTRACT_TYPES]}
+          value={filter.type ?? ''}
+          onChange={(e) =>
+            setFilter((f) => ({
+              ...f,
+              type: (e.target.value || undefined) as ContractType | undefined,
+              page: 1,
+            }))
+          }
+          className="w-36"
+        />
+        <Select
+          options={[{ value: '', label: 'All Statuses' }, ...CONTRACT_STATUSES]}
+          value={filter.status ?? ''}
+          onChange={(e) =>
+            setFilter((f) => ({
+              ...f,
+              status: (e.target.value || undefined) as ContractStatus | undefined,
+              page: 1,
+            }))
+          }
+          className="w-40"
+        />
+        <div className="flex items-end gap-2">
+          <div className="flex flex-col">
+            <label className="text-xs text-gray-500 mb-1">From</label>
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={(e) => {
+                setDateFrom(e.target.value)
+                handleDateFilter()
+              }}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label className="text-xs text-gray-500 mb-1">To</label>
+            <input
+              type="date"
+              value={dateTo}
+              onChange={(e) => {
+                setDateTo(e.target.value)
+                handleDateFilter()
+              }}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            />
+          </div>
+          {(dateFrom || dateTo) && (
+            <button
+              onClick={() => {
+                setDateFrom('')
+                setDateTo('')
+                handleDateFilter()
+              }}
+              className="text-xs text-red-500 hover:text-red-700 pb-2"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Table */}
+      <DataTable
+        columns={columns}
+        data={(data?.data ?? []) as Record<string, unknown>[]}
+        loading={isLoading}
+        page={filter.page}
+        pageSize={filter.pageSize}
+        total={data?.total}
+        onPageChange={(p) => setFilter((f) => ({ ...f, page: p }))}
+        onPageSizeChange={(ps) => setFilter((f) => ({ ...f, pageSize: ps, page: 1 }))}
+        onRowClick={(row) => navigate(`/contracts/${String(row.id)}`)}
+        emptyMessage="No contracts found."
+      />
+    </div>
+  )
+}

--- a/admin-ui/src/pages/invoices/InvoiceDetailPage.tsx
+++ b/admin-ui/src/pages/invoices/InvoiceDetailPage.tsx
@@ -1,0 +1,274 @@
+import { useState } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import {
+  ArrowLeft,
+  Receipt,
+  FileText,
+  DollarSign,
+  Calendar,
+  User,
+  Home,
+  CreditCard,
+  XCircle,
+} from 'lucide-react'
+import { Button, LoadingSpinner } from '../../components/ui'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { useInvoiceDetail, useCancelInvoice } from '../../hooks/useInvoices'
+import { RecordPaymentDialog } from '../../components/invoices/RecordPaymentDialog'
+import { formatDate, formatCurrency } from '../../utils'
+import toast from 'react-hot-toast'
+
+const statusBadge: Record<string, string> = {
+  PENDING: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  PAID: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  OVERDUE: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  CANCELLED: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  REFUNDED: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+}
+
+export default function InvoiceDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { data: invoice, isLoading, isError } = useInvoiceDetail(id!)
+  const cancelMutation = useCancelInvoice()
+
+  const [paymentOpen, setPaymentOpen] = useState(false)
+  const [cancelOpen, setCancelOpen] = useState(false)
+
+  if (isLoading) return <LoadingSpinner message="Loading invoice..." />
+  if (isError || !invoice) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16">
+        <p className="text-gray-500">Invoice not found.</p>
+        <Button variant="secondary" onClick={() => navigate('/invoices')}>
+          Back to Invoices
+        </Button>
+      </div>
+    )
+  }
+
+  const canPay = invoice.status === 'PENDING' || invoice.status === 'OVERDUE'
+  const canCancel = invoice.status === 'PENDING' || invoice.status === 'OVERDUE'
+
+  async function handleCancel() {
+    try {
+      await cancelMutation.mutateAsync(id!)
+      toast.success('Invoice cancelled')
+      setCancelOpen(false)
+    } catch {
+      toast.error('Failed to cancel invoice')
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate('/invoices')}
+            className="rounded-lg p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800"
+          >
+            <ArrowLeft size={20} />
+          </button>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              Invoice
+            </h1>
+            <div className="flex items-center gap-2 mt-0.5">
+              <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${statusBadge[invoice.status]}`}>
+                {invoice.status}
+              </span>
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                Created {formatDate(invoice.createdAt)}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {canPay && (
+            <Button
+              leftIcon={<CreditCard size={16} />}
+              onClick={() => setPaymentOpen(true)}
+            >
+              Record Payment
+            </Button>
+          )}
+          {canCancel && (
+            <Button
+              variant="secondary"
+              leftIcon={<XCircle size={16} />}
+              onClick={() => setCancelOpen(true)}
+            >
+              Cancel Invoice
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Invoice Info */}
+        <div className="lg:col-span-1 space-y-6">
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
+              <Receipt size={18} className="text-indigo-500" /> Invoice Details
+            </h2>
+            <dl className="space-y-3 text-sm">
+              <div className="flex justify-between">
+                <dt className="text-gray-500 flex items-center gap-1">
+                  <DollarSign size={14} /> Amount
+                </dt>
+                <dd className="font-semibold text-gray-900 dark:text-gray-100 text-lg">
+                  {formatCurrency(invoice.amount)}
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-gray-500 flex items-center gap-1">
+                  <Calendar size={14} /> Due Date
+                </dt>
+                <dd className={`font-medium ${
+                  (invoice.status === 'PENDING' || invoice.status === 'OVERDUE') && new Date(invoice.dueDate) < new Date()
+                    ? 'text-red-500'
+                    : 'text-gray-700 dark:text-gray-300'
+                }`}>
+                  {formatDate(invoice.dueDate)}
+                </dd>
+              </div>
+              {invoice.paidDate && (
+                <div className="flex justify-between">
+                  <dt className="text-gray-500">Paid Date</dt>
+                  <dd className="text-green-600 font-medium">{formatDate(invoice.paidDate)}</dd>
+                </div>
+              )}
+              {invoice.paymentMethod && (
+                <div className="flex justify-between">
+                  <dt className="text-gray-500">Payment Method</dt>
+                  <dd className="text-gray-700 dark:text-gray-300">
+                    {invoice.paymentMethod.replace('_', ' ')}
+                  </dd>
+                </div>
+              )}
+              {invoice.notes && (
+                <div className="pt-2 border-t border-gray-100 dark:border-gray-700">
+                  <dt className="text-xs font-medium text-gray-500 mb-1">Notes</dt>
+                  <dd className="text-gray-700 dark:text-gray-300 whitespace-pre-line">
+                    {invoice.notes}
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        </div>
+
+        {/* Contract Info */}
+        <div className="lg:col-span-2 space-y-6">
+          {invoice.contract && (
+            <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
+                <FileText size={18} className="text-indigo-500" /> Contract Info
+              </h2>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <Link
+                  to={`/contracts/${invoice.contract.id}`}
+                  className="block rounded-lg border border-gray-100 dark:border-gray-700 p-4 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <FileText size={16} className="text-gray-400" />
+                    <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                      {invoice.contract.type} Contract
+                    </span>
+                  </div>
+                  <div className="space-y-1 text-xs text-gray-500">
+                    <p>Status: {invoice.contract.status}</p>
+                    <p>Total: {formatCurrency(invoice.contract.totalAmount)}</p>
+                    <p>
+                      {formatDate(invoice.contract.startDate)}
+                      {invoice.contract.endDate && ` - ${formatDate(invoice.contract.endDate)}`}
+                    </p>
+                  </div>
+                </Link>
+
+                {invoice.contract.property && (
+                  <Link
+                    to={`/properties/${invoice.contract.property.id}`}
+                    className="block rounded-lg border border-gray-100 dark:border-gray-700 p-4 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+                  >
+                    <div className="flex items-center gap-2 mb-2">
+                      <Home size={16} className="text-gray-400" />
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        Property
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-700 dark:text-gray-300">
+                      {invoice.contract.property.title}
+                    </p>
+                    {invoice.contract.property.address && (
+                      <p className="text-xs text-gray-500 mt-0.5">
+                        {invoice.contract.property.address}
+                      </p>
+                    )}
+                  </Link>
+                )}
+
+                {invoice.contract.client && (
+                  <Link
+                    to={`/clients/${invoice.contract.client.id}`}
+                    className="block rounded-lg border border-gray-100 dark:border-gray-700 p-4 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+                  >
+                    <div className="flex items-center gap-2 mb-2">
+                      <User size={16} className="text-gray-400" />
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        Client
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-700 dark:text-gray-300">
+                      {invoice.contract.client.firstName} {invoice.contract.client.lastName}
+                    </p>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                      {invoice.contract.client.phone}
+                    </p>
+                    {invoice.contract.client.email && (
+                      <p className="text-xs text-gray-500">{invoice.contract.client.email}</p>
+                    )}
+                  </Link>
+                )}
+
+                {invoice.contract.agent && (
+                  <div className="rounded-lg border border-gray-100 dark:border-gray-700 p-4">
+                    <div className="flex items-center gap-2 mb-2">
+                      <User size={16} className="text-gray-400" />
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        Agent
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-700 dark:text-gray-300">
+                      {invoice.contract.agent.name}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Record Payment Dialog */}
+      <RecordPaymentDialog
+        isOpen={paymentOpen}
+        invoiceId={id!}
+        onClose={() => setPaymentOpen(false)}
+      />
+
+      {/* Cancel Dialog */}
+      <ConfirmDialog
+        isOpen={cancelOpen}
+        title="Cancel Invoice"
+        message="Are you sure you want to cancel this invoice? This action cannot be undone."
+        confirmLabel="Cancel Invoice"
+        onConfirm={handleCancel}
+        onCancel={() => setCancelOpen(false)}
+        loading={cancelMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/admin-ui/src/pages/invoices/InvoicesListPage.tsx
+++ b/admin-ui/src/pages/invoices/InvoicesListPage.tsx
@@ -1,0 +1,261 @@
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  Receipt,
+  DollarSign,
+  AlertTriangle,
+  CheckCircle,
+  Clock,
+} from 'lucide-react'
+import { Button, DataTable, Select, StatsCard } from '../../components/ui'
+import { useInvoicesList, useInvoiceStats } from '../../hooks/useInvoices'
+import { formatDate, formatCurrency } from '../../utils'
+import type { InvoiceStatus, InvoiceFilter } from '../../types/invoice'
+import type { Column } from '../../types'
+
+const INVOICE_STATUSES: { value: InvoiceStatus; label: string }[] = [
+  { value: 'PENDING', label: 'Pending' },
+  { value: 'PAID', label: 'Paid' },
+  { value: 'OVERDUE', label: 'Overdue' },
+  { value: 'CANCELLED', label: 'Cancelled' },
+  { value: 'REFUNDED', label: 'Refunded' },
+]
+
+const statusBadge: Record<string, string> = {
+  PENDING: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  PAID: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  OVERDUE: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  CANCELLED: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  REFUNDED: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+}
+
+export default function InvoicesListPage() {
+  const navigate = useNavigate()
+  const [filter, setFilter] = useState<InvoiceFilter>({
+    page: 1,
+    pageSize: 10,
+    sortBy: 'dueDate',
+    sortOrder: 'asc',
+  })
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
+
+  const effectiveFilter: InvoiceFilter = {
+    ...filter,
+    ...(dateFrom ? { dateFrom } : {}),
+    ...(dateTo ? { dateTo } : {}),
+  }
+
+  const { data, isLoading } = useInvoicesList(effectiveFilter)
+  const { data: stats } = useInvoiceStats()
+
+  const handleDateFilter = useCallback(() => {
+    setFilter((f) => ({ ...f, page: 1 }))
+  }, [])
+
+  const columns: Column[] = [
+    {
+      key: 'contract',
+      header: 'Contract / Property',
+      render: (_v, row) => {
+        const contract = row.contract as { type?: string; property?: { title?: string }; client?: { firstName?: string; lastName?: string } } | null
+        return (
+          <div className="flex flex-col">
+            <span className="font-medium text-gray-900 dark:text-gray-100">
+              {contract?.property?.title ?? 'N/A'}
+            </span>
+            <span className="text-xs text-gray-500">
+              {contract?.client
+                ? `${contract.client.firstName} ${contract.client.lastName}`
+                : 'N/A'}
+              {contract?.type && ` - ${contract.type}`}
+            </span>
+          </div>
+        )
+      },
+    },
+    {
+      key: 'amount',
+      header: 'Amount',
+      sortable: true,
+      render: (v) => (
+        <span className="font-medium text-gray-900 dark:text-gray-100">
+          {formatCurrency(Number(v))}
+        </span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      sortable: true,
+      render: (v) => (
+        <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${statusBadge[String(v)] ?? ''}`}>
+          {String(v)}
+        </span>
+      ),
+    },
+    {
+      key: 'dueDate',
+      header: 'Due Date',
+      sortable: true,
+      render: (v) => {
+        const date = new Date(String(v))
+        const isOverdue = date < new Date()
+        return (
+          <span className={`text-xs ${isOverdue ? 'text-red-500 font-medium' : 'text-gray-500'}`}>
+            {formatDate(String(v))}
+          </span>
+        )
+      },
+    },
+    {
+      key: 'paidDate',
+      header: 'Paid Date',
+      render: (v) => (
+        <span className="text-gray-500 text-xs">
+          {v ? formatDate(String(v)) : '-'}
+        </span>
+      ),
+    },
+    {
+      key: 'paymentMethod',
+      header: 'Method',
+      render: (v) => (
+        <span className="text-gray-600 dark:text-gray-400 text-xs">
+          {v ? String(v).replace('_', ' ') : '-'}
+        </span>
+      ),
+    },
+    {
+      key: 'createdAt',
+      header: 'Created',
+      sortable: true,
+      render: (v) => <span className="text-gray-500 text-xs">{formatDate(String(v))}</span>,
+    },
+  ]
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Receipt size={24} className="text-indigo-500" />
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Invoices</h1>
+        </div>
+      </div>
+
+      {/* Stats */}
+      {stats && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <StatsCard
+            title="Total Collected"
+            value={formatCurrency(stats.totalCollected ?? 0)}
+            icon={DollarSign}
+            color="green"
+          />
+          <StatsCard
+            title="Total Due"
+            value={formatCurrency(stats.totalDue ?? 0)}
+            icon={Clock}
+            color="amber"
+          />
+          <StatsCard
+            title="Overdue"
+            value={stats.overdueCount ?? 0}
+            icon={AlertTriangle}
+            color="red"
+          />
+          <StatsCard
+            title="Paid"
+            value={stats.paidCount ?? 0}
+            icon={CheckCircle}
+            color="green"
+          />
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-end gap-3">
+        <Select
+          options={[{ value: '', label: 'All Statuses' }, ...INVOICE_STATUSES]}
+          value={filter.status ?? ''}
+          onChange={(e) =>
+            setFilter((f) => ({
+              ...f,
+              status: (e.target.value || undefined) as InvoiceStatus | undefined,
+              page: 1,
+            }))
+          }
+          className="w-40"
+        />
+        <div className="flex items-end gap-2">
+          <div className="flex flex-col">
+            <label className="text-xs text-gray-500 mb-1">Due From</label>
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={(e) => {
+                setDateFrom(e.target.value)
+                handleDateFilter()
+              }}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label className="text-xs text-gray-500 mb-1">Due To</label>
+            <input
+              type="date"
+              value={dateTo}
+              onChange={(e) => {
+                setDateTo(e.target.value)
+                handleDateFilter()
+              }}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            />
+          </div>
+          {(dateFrom || dateTo) && (
+            <button
+              onClick={() => {
+                setDateFrom('')
+                setDateTo('')
+                handleDateFilter()
+              }}
+              className="text-xs text-red-500 hover:text-red-700 pb-2"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() =>
+            setFilter((f) => ({
+              ...f,
+              overdue: f.overdue === 'true' ? undefined : 'true',
+              page: 1,
+            }))
+          }
+          className={filter.overdue === 'true' ? 'ring-2 ring-red-500' : ''}
+        >
+          <AlertTriangle size={14} className="mr-1" />
+          Overdue Only
+        </Button>
+      </div>
+
+      {/* Table */}
+      <DataTable
+        columns={columns}
+        data={(data?.data ?? []) as Record<string, unknown>[]}
+        loading={isLoading}
+        page={filter.page}
+        pageSize={filter.pageSize}
+        total={data?.total}
+        onPageChange={(p) => setFilter((f) => ({ ...f, page: p }))}
+        onPageSizeChange={(ps) => setFilter((f) => ({ ...f, pageSize: ps, page: 1 }))}
+        onRowClick={(row) => navigate(`/invoices/${String(row.id)}`)}
+        emptyMessage="No invoices found."
+      />
+    </div>
+  )
+}

--- a/admin-ui/src/pages/reports/ReportsPage.tsx
+++ b/admin-ui/src/pages/reports/ReportsPage.tsx
@@ -1,0 +1,588 @@
+import { useState, useCallback } from 'react'
+import {
+  BarChart3,
+  Download,
+  DollarSign,
+  Users,
+  Building2,
+  TrendingUp,
+} from 'lucide-react'
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  PieChart,
+  Pie,
+  Cell,
+  AreaChart,
+  Area,
+} from 'recharts'
+import { Button, Skeleton } from '../../components/ui'
+import { ChartCard, DateRangeFilter } from '../../components/dashboard'
+import { useRevenueReport, useLeadConversionReport, usePropertyReport } from '../../hooks/useReports'
+import { reportsApi } from '../../api/reports'
+import type { DateRangePreset } from '../../types/dashboard'
+import type { RevenueReportParams, LeadConversionParams } from '../../types/reports'
+
+const COLORS = ['#6366f1', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#ec4899', '#14b8a6']
+
+function formatCurrency(value: number): string {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`
+  return `$${value.toFixed(0)}`
+}
+
+function downloadBlob(data: Blob, filename: string) {
+  const url = URL.createObjectURL(data)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}
+
+type Tab = 'revenue' | 'leads' | 'properties'
+
+export default function ReportsPage() {
+  const [activeTab, setActiveTab] = useState<Tab>('revenue')
+  const [range, setRange] = useState<DateRangePreset>('this_month')
+  const [exporting, setExporting] = useState(false)
+
+  const revenueParams: RevenueReportParams = { range, groupBy: 'day' }
+  const leadParams: LeadConversionParams = { range }
+
+  const revenue = useRevenueReport(revenueParams)
+  const leadConversion = useLeadConversionReport(leadParams)
+  const propertyReport = usePropertyReport()
+
+  const handleExportRevenue = useCallback(async () => {
+    setExporting(true)
+    try {
+      const blob = await reportsApi.exportRevenueCsv(revenueParams)
+      downloadBlob(blob, `revenue-report-${range}.csv`)
+    } catch {
+      // Fallback: generate CSV client-side from available data
+      if (revenue.data?.data) {
+        const header = 'Period,Revenue,Contracts,Avg Deal Size\n'
+        const rows = revenue.data.data
+          .map((r) => `${r.period},${r.revenue},${r.contracts},${r.avgDealSize}`)
+          .join('\n')
+        const blob = new Blob([header + rows], { type: 'text/csv' })
+        downloadBlob(blob, `revenue-report-${range}.csv`)
+      }
+    } finally {
+      setExporting(false)
+    }
+  }, [range, revenue.data, revenueParams])
+
+  const handleExportLeads = useCallback(async () => {
+    setExporting(true)
+    try {
+      const blob = await reportsApi.exportLeadsCsv(leadParams)
+      downloadBlob(blob, `leads-report-${range}.csv`)
+    } catch {
+      if (leadConversion.data?.bySource) {
+        const header = 'Source,Total,Converted,Conversion Rate %\n'
+        const rows = leadConversion.data.bySource
+          .map((r) => `${r.source},${r.total},${r.converted},${r.conversionRate}`)
+          .join('\n')
+        const blob = new Blob([header + rows], { type: 'text/csv' })
+        downloadBlob(blob, `leads-report-${range}.csv`)
+      }
+    } finally {
+      setExporting(false)
+    }
+  }, [range, leadConversion.data, leadParams])
+
+  const tabs: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
+    { key: 'revenue', label: 'Revenue', icon: DollarSign },
+    { key: 'leads', label: 'Lead Conversion', icon: Users },
+    { key: 'properties', label: 'Properties', icon: Building2 },
+  ]
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <BarChart3 size={24} className="text-indigo-500" />
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Reports</h1>
+        </div>
+        <DateRangeFilter value={range} onChange={setRange} />
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 rounded-lg border border-gray-200 bg-white p-1 dark:border-gray-700 dark:bg-gray-800 w-fit">
+        {tabs.map((tab) => {
+          const Icon = tab.icon
+          return (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={
+                activeTab === tab.key
+                  ? 'flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm'
+                  : 'flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700'
+              }
+            >
+              <Icon size={16} />
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Revenue Tab */}
+      {activeTab === 'revenue' && (
+        <div className="flex flex-col gap-6">
+          {/* Summary Stats */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Total Revenue</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {revenue.data ? formatCurrency(revenue.data.total) : '--'}
+              </p>
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Total Contracts</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {revenue.data?.data
+                  ? revenue.data.data.reduce((sum, r) => sum + r.contracts, 0)
+                  : '--'}
+              </p>
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Avg Deal Size</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {revenue.data?.data?.length
+                  ? formatCurrency(
+                      revenue.data.data.reduce((sum, r) => sum + r.avgDealSize, 0) /
+                        revenue.data.data.length,
+                    )
+                  : '--'}
+              </p>
+            </div>
+          </div>
+
+          {/* Revenue Timeline Chart */}
+          <ChartCard
+            title="Revenue Over Time"
+            subtitle={revenue.data?.period ? `${revenue.data.period.start} — ${revenue.data.period.end}` : undefined}
+            action={
+              <Button
+                variant="secondary"
+                size="sm"
+                leftIcon={<Download size={14} />}
+                loading={exporting}
+                onClick={handleExportRevenue}
+              >
+                Export CSV
+              </Button>
+            }
+          >
+            {revenue.isLoading ? (
+              <Skeleton height="h-72" />
+            ) : revenue.data?.data?.length ? (
+              <div className="h-72">
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={revenue.data.data} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
+                    <defs>
+                      <linearGradient id="reportRevenueGrad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#6366f1" stopOpacity={0.3} />
+                        <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                    <XAxis dataKey="period" tick={{ fontSize: 11 }} />
+                    <YAxis tickFormatter={formatCurrency} tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      formatter={(value: number) => [formatCurrency(value), 'Revenue']}
+                      contentStyle={{
+                        backgroundColor: 'rgba(17, 24, 39, 0.9)',
+                        border: 'none',
+                        borderRadius: '8px',
+                        color: '#f9fafb',
+                        fontSize: '12px',
+                      }}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="revenue"
+                      stroke="#6366f1"
+                      strokeWidth={2}
+                      fill="url(#reportRevenueGrad)"
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
+            ) : (
+              <div className="flex h-72 items-center justify-center text-sm text-gray-400">
+                No revenue data for this period
+              </div>
+            )}
+          </ChartCard>
+
+          {/* Revenue by Contracts Bar Chart */}
+          <ChartCard title="Contracts & Average Deal Size">
+            {revenue.isLoading ? (
+              <Skeleton height="h-64" />
+            ) : revenue.data?.data?.length ? (
+              <div className="h-64">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={revenue.data.data} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                    <XAxis dataKey="period" tick={{ fontSize: 11 }} />
+                    <YAxis tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: 'rgba(17, 24, 39, 0.9)',
+                        border: 'none',
+                        borderRadius: '8px',
+                        color: '#f9fafb',
+                        fontSize: '12px',
+                      }}
+                    />
+                    <Legend />
+                    <Bar dataKey="contracts" fill="#6366f1" name="Contracts" radius={[4, 4, 0, 0]} />
+                    <Bar dataKey="avgDealSize" fill="#22c55e" name="Avg Deal Size ($)" radius={[4, 4, 0, 0]} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            ) : (
+              <div className="flex h-64 items-center justify-center text-sm text-gray-400">
+                No data available
+              </div>
+            )}
+          </ChartCard>
+        </div>
+      )}
+
+      {/* Lead Conversion Tab */}
+      {activeTab === 'leads' && (
+        <div className="flex flex-col gap-6">
+          {/* Overall Stats */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Total Leads</p>
+              <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {leadConversion.data?.overall.total ?? '--'}
+              </p>
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Converted</p>
+              <p className="mt-1 text-2xl font-bold text-green-600 dark:text-green-400">
+                {leadConversion.data?.overall.converted ?? '--'}
+              </p>
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Conversion Rate</p>
+                <TrendingUp size={14} className="text-green-500" />
+              </div>
+              <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {leadConversion.data?.overall.conversionRate != null
+                  ? `${leadConversion.data.overall.conversionRate}%`
+                  : '--'}
+              </p>
+            </div>
+          </div>
+
+          {/* Lead Conversion by Source */}
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <ChartCard
+              title="Conversion by Source"
+              action={
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  leftIcon={<Download size={14} />}
+                  loading={exporting}
+                  onClick={handleExportLeads}
+                >
+                  Export CSV
+                </Button>
+              }
+            >
+              {leadConversion.isLoading ? (
+                <Skeleton height="h-64" />
+              ) : leadConversion.data?.bySource?.length ? (
+                <div className="h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart
+                      data={leadConversion.data.bySource}
+                      layout="vertical"
+                      margin={{ top: 5, right: 20, left: 60, bottom: 0 }}
+                    >
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                      <XAxis type="number" tick={{ fontSize: 11 }} />
+                      <YAxis type="category" dataKey="source" tick={{ fontSize: 11 }} width={80} />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: 'rgba(17, 24, 39, 0.9)',
+                          border: 'none',
+                          borderRadius: '8px',
+                          color: '#f9fafb',
+                          fontSize: '12px',
+                        }}
+                      />
+                      <Legend />
+                      <Bar dataKey="total" fill="#6366f1" name="Total" radius={[0, 4, 4, 0]} />
+                      <Bar dataKey="converted" fill="#22c55e" name="Converted" radius={[0, 4, 4, 0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <div className="flex h-64 items-center justify-center text-sm text-gray-400">
+                  No lead conversion data
+                </div>
+              )}
+            </ChartCard>
+
+            <ChartCard title="Conversion Rate by Source">
+              {leadConversion.isLoading ? (
+                <Skeleton height="h-64" />
+              ) : leadConversion.data?.bySource?.length ? (
+                <div className="h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                      <Pie
+                        data={leadConversion.data.bySource}
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={90}
+                        dataKey="converted"
+                        nameKey="source"
+                        label={({ source, conversionRate }) => `${source}: ${conversionRate}%`}
+                        labelLine={false}
+                      >
+                        {leadConversion.data.bySource.map((_, index) => (
+                          <Cell key={index} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: 'rgba(17, 24, 39, 0.9)',
+                          border: 'none',
+                          borderRadius: '8px',
+                          color: '#f9fafb',
+                          fontSize: '12px',
+                        }}
+                      />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <div className="flex h-64 items-center justify-center text-sm text-gray-400">
+                  No data available
+                </div>
+              )}
+            </ChartCard>
+          </div>
+
+          {/* Conversion Table */}
+          <ChartCard title="Detailed Conversion Breakdown">
+            {leadConversion.isLoading ? (
+              <Skeleton height="h-48" />
+            ) : leadConversion.data?.bySource?.length ? (
+              <div className="overflow-x-auto">
+                <table className="w-full text-left text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-200 text-xs font-medium uppercase text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                      <th className="pb-3 pr-4">Source</th>
+                      <th className="pb-3 pr-4 text-right">Total Leads</th>
+                      <th className="pb-3 pr-4 text-right">Converted</th>
+                      <th className="pb-3 text-right">Conversion Rate</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {leadConversion.data.bySource.map((item) => (
+                      <tr
+                        key={item.source}
+                        className="border-b border-gray-100 last:border-0 dark:border-gray-700/50"
+                      >
+                        <td className="py-2.5 pr-4 font-medium text-gray-700 dark:text-gray-300">
+                          {item.source}
+                        </td>
+                        <td className="py-2.5 pr-4 text-right text-gray-600 dark:text-gray-400">
+                          {item.total}
+                        </td>
+                        <td className="py-2.5 pr-4 text-right text-green-600 dark:text-green-400">
+                          {item.converted}
+                        </td>
+                        <td className="py-2.5 text-right font-medium text-gray-800 dark:text-gray-200">
+                          {item.conversionRate}%
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="py-8 text-center text-sm text-gray-400">No lead data available</p>
+            )}
+          </ChartCard>
+        </div>
+      )}
+
+      {/* Properties Tab */}
+      {activeTab === 'properties' && (
+        <div className="flex flex-col gap-6">
+          {/* Property Totals */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+            {[
+              { label: 'Total', value: propertyReport.data?.totals.total, color: 'text-gray-900 dark:text-gray-100' },
+              { label: 'Available', value: propertyReport.data?.totals.available, color: 'text-green-600 dark:text-green-400' },
+              { label: 'Sold', value: propertyReport.data?.totals.sold, color: 'text-indigo-600 dark:text-indigo-400' },
+              { label: 'Rented', value: propertyReport.data?.totals.rented, color: 'text-amber-600 dark:text-amber-400' },
+            ].map((stat) => (
+              <div
+                key={stat.label}
+                className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+              >
+                <p className="text-sm font-medium text-gray-500 dark:text-gray-400">{stat.label}</p>
+                <p className={`mt-1 text-2xl font-bold ${stat.color}`}>
+                  {stat.value ?? '--'}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {/* Properties by Type - Bar Chart */}
+            <ChartCard title="Properties by Type">
+              {propertyReport.isLoading ? (
+                <Skeleton height="h-64" />
+              ) : propertyReport.data?.byType?.length ? (
+                <div className="h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={propertyReport.data.byType} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+                      <XAxis dataKey="type" tick={{ fontSize: 11 }} />
+                      <YAxis tick={{ fontSize: 11 }} />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: 'rgba(17, 24, 39, 0.9)',
+                          border: 'none',
+                          borderRadius: '8px',
+                          color: '#f9fafb',
+                          fontSize: '12px',
+                        }}
+                      />
+                      <Bar dataKey="total" fill="#6366f1" name="Total" radius={[4, 4, 0, 0]} />
+                      <Bar dataKey="available" fill="#22c55e" name="Available" radius={[4, 4, 0, 0]} />
+                      <Bar dataKey="sold" fill="#f59e0b" name="Sold" radius={[4, 4, 0, 0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <div className="flex h-64 items-center justify-center text-sm text-gray-400">
+                  No property data
+                </div>
+              )}
+            </ChartCard>
+
+            {/* Properties by Type - Pie */}
+            <ChartCard title="Distribution by Type">
+              {propertyReport.isLoading ? (
+                <Skeleton height="h-64" />
+              ) : propertyReport.data?.byType?.length ? (
+                <div className="h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                      <Pie
+                        data={propertyReport.data.byType}
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={90}
+                        dataKey="total"
+                        nameKey="type"
+                        label={({ type, total }) => `${type}: ${total}`}
+                        labelLine={false}
+                      >
+                        {propertyReport.data.byType.map((_, index) => (
+                          <Cell key={index} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: 'rgba(17, 24, 39, 0.9)',
+                          border: 'none',
+                          borderRadius: '8px',
+                          color: '#f9fafb',
+                          fontSize: '12px',
+                        }}
+                      />
+                      <Legend />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <div className="flex h-64 items-center justify-center text-sm text-gray-400">
+                  No data available
+                </div>
+              )}
+            </ChartCard>
+          </div>
+
+          {/* Detailed Table */}
+          <ChartCard title="Property Details by Type">
+            {propertyReport.isLoading ? (
+              <Skeleton height="h-48" />
+            ) : propertyReport.data?.byType?.length ? (
+              <div className="overflow-x-auto">
+                <table className="w-full text-left text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-200 text-xs font-medium uppercase text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                      <th className="pb-3 pr-4">Type</th>
+                      <th className="pb-3 pr-4 text-right">Total</th>
+                      <th className="pb-3 pr-4 text-right">Available</th>
+                      <th className="pb-3 pr-4 text-right">Sold</th>
+                      <th className="pb-3 pr-4 text-right">Rented</th>
+                      <th className="pb-3 text-right">Avg Price</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {propertyReport.data.byType.map((item) => (
+                      <tr
+                        key={item.type}
+                        className="border-b border-gray-100 last:border-0 dark:border-gray-700/50"
+                      >
+                        <td className="py-2.5 pr-4 font-medium text-gray-700 dark:text-gray-300">
+                          {item.type}
+                        </td>
+                        <td className="py-2.5 pr-4 text-right text-gray-600 dark:text-gray-400">
+                          {item.total}
+                        </td>
+                        <td className="py-2.5 pr-4 text-right text-green-600 dark:text-green-400">
+                          {item.available}
+                        </td>
+                        <td className="py-2.5 pr-4 text-right text-indigo-600 dark:text-indigo-400">
+                          {item.sold}
+                        </td>
+                        <td className="py-2.5 pr-4 text-right text-amber-600 dark:text-amber-400">
+                          {item.rented}
+                        </td>
+                        <td className="py-2.5 text-right font-medium text-gray-800 dark:text-gray-200">
+                          {formatCurrency(item.avgPrice)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="py-8 text-center text-sm text-gray-400">No property data available</p>
+            )}
+          </ChartCard>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/admin-ui/src/pages/settings/SettingsPage.tsx
+++ b/admin-ui/src/pages/settings/SettingsPage.tsx
@@ -1,0 +1,302 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Settings, Building, Tag, Radio, Plus, Trash2, Save } from 'lucide-react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import { Button, Input } from '../../components/ui'
+import { settingsApi } from '../../api/settings'
+import type { CompanySettings, ConfigItem } from '../../types/reports'
+
+type Tab = 'company' | 'property-types' | 'lead-sources'
+
+export default function SettingsPage() {
+  const [activeTab, setActiveTab] = useState<Tab>('company')
+
+  const tabs: { key: Tab; label: string; icon: typeof Settings }[] = [
+    { key: 'company', label: 'Company Info', icon: Building },
+    { key: 'property-types', label: 'Property Types', icon: Tag },
+    { key: 'lead-sources', label: 'Lead Sources', icon: Radio },
+  ]
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Settings size={24} className="text-indigo-500" />
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Settings</h1>
+          <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+            Manage company information and configuration
+          </p>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 rounded-lg border border-gray-200 bg-white p-1 dark:border-gray-700 dark:bg-gray-800 w-fit">
+        {tabs.map((tab) => {
+          const Icon = tab.icon
+          return (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={
+                activeTab === tab.key
+                  ? 'flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm'
+                  : 'flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700'
+              }
+            >
+              <Icon size={16} />
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+
+      {activeTab === 'company' && <CompanyInfoSection />}
+      {activeTab === 'property-types' && <ConfigListSection kind="property-types" title="Property Types" />}
+      {activeTab === 'lead-sources' && <ConfigListSection kind="lead-sources" title="Lead Sources" />}
+    </div>
+  )
+}
+
+// ─── Company Info Section ─────────────────────────────────────────────────
+
+function CompanyInfoSection() {
+  const queryClient = useQueryClient()
+  const { data, isLoading } = useQuery({
+    queryKey: ['settings', 'company'],
+    queryFn: () => settingsApi.getCompany(),
+    staleTime: 300_000,
+  })
+
+  const [form, setForm] = useState<CompanySettings>({
+    name: '',
+    address: '',
+    phone: '',
+    email: '',
+    website: '',
+  })
+
+  useEffect(() => {
+    if (data) setForm(data)
+  }, [data])
+
+  const mutation = useMutation({
+    mutationFn: (payload: CompanySettings) => settingsApi.updateCompany(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings', 'company'] })
+      toast.success('Company info updated')
+    },
+    onError: () => {
+      toast.error('Failed to update company info')
+    },
+  })
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      mutation.mutate(form)
+    },
+    [form, mutation],
+  )
+
+  function updateField(field: keyof CompanySettings, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  if (isLoading) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+        <div className="space-y-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-10 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-700" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+    >
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <div className="sm:col-span-2">
+          <Input
+            label="Company Name"
+            value={form.name}
+            onChange={(e) => updateField('name', e.target.value)}
+            placeholder="Your Company Name"
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <Input
+            label="Address"
+            value={form.address}
+            onChange={(e) => updateField('address', e.target.value)}
+            placeholder="123 Main St, City, Country"
+          />
+        </div>
+        <Input
+          label="Phone"
+          value={form.phone}
+          onChange={(e) => updateField('phone', e.target.value)}
+          placeholder="+1 (555) 123-4567"
+        />
+        <Input
+          label="Email"
+          type="email"
+          value={form.email}
+          onChange={(e) => updateField('email', e.target.value)}
+          placeholder="info@company.com"
+        />
+        <div className="sm:col-span-2">
+          <Input
+            label="Website"
+            value={form.website}
+            onChange={(e) => updateField('website', e.target.value)}
+            placeholder="https://www.company.com"
+          />
+        </div>
+      </div>
+      <div className="mt-6 flex justify-end">
+        <Button type="submit" loading={mutation.isPending} leftIcon={<Save size={16} />}>
+          Save Changes
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+// ─── Config List Section (Property Types / Lead Sources) ──────────────────
+
+function ConfigListSection({ kind, title }: { kind: 'property-types' | 'lead-sources'; title: string }) {
+  const queryClient = useQueryClient()
+
+  const fetchFn = kind === 'property-types' ? settingsApi.getPropertyTypes : settingsApi.getLeadSources
+  const updateFn = kind === 'property-types' ? settingsApi.updatePropertyTypes : settingsApi.updateLeadSources
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['settings', kind],
+    queryFn: fetchFn,
+    staleTime: 300_000,
+  })
+
+  const [items, setItems] = useState<ConfigItem[]>([])
+
+  useEffect(() => {
+    if (data) setItems(data)
+  }, [data])
+
+  const mutation = useMutation({
+    mutationFn: (payload: ConfigItem[]) => updateFn(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings', kind] })
+      toast.success(`${title} updated`)
+    },
+    onError: () => {
+      toast.error(`Failed to update ${title.toLowerCase()}`)
+    },
+  })
+
+  function addItem() {
+    setItems((prev) => [
+      ...prev,
+      {
+        id: `new-${Date.now()}`,
+        label: '',
+        value: '',
+        isActive: true,
+      },
+    ])
+  }
+
+  function updateItem(index: number, field: keyof ConfigItem, value: string | boolean) {
+    setItems((prev) =>
+      prev.map((item, i) => (i === index ? { ...item, [field]: value } : item)),
+    )
+  }
+
+  function removeItem(index: number) {
+    setItems((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  function handleSave() {
+    const filtered = items.filter((item) => item.label.trim() || item.value.trim())
+    mutation.mutate(filtered)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-10 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-700" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="font-semibold text-gray-800 dark:text-gray-200">{title}</h2>
+        <Button variant="secondary" size="sm" leftIcon={<Plus size={14} />} onClick={addItem}>
+          Add
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="py-8 text-center text-sm text-gray-400">
+          No {title.toLowerCase()} configured. Click "Add" to create one.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {items.map((item, index) => (
+            <div
+              key={item.id}
+              className="flex items-center gap-3 rounded-lg border border-gray-100 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/50"
+            >
+              <input
+                type="text"
+                value={item.label}
+                onChange={(e) => updateItem(index, 'label', e.target.value)}
+                placeholder="Label"
+                className="flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:placeholder-gray-500"
+              />
+              <input
+                type="text"
+                value={item.value}
+                onChange={(e) => updateItem(index, 'value', e.target.value)}
+                placeholder="Value"
+                className="flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:placeholder-gray-500"
+              />
+              <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={item.isActive}
+                  onChange={(e) => updateItem(index, 'isActive', e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                Active
+              </label>
+              <button
+                onClick={() => removeItem(index)}
+                className="rounded p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20"
+              >
+                <Trash2 size={16} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-5 flex justify-end">
+        <Button loading={mutation.isPending} leftIcon={<Save size={16} />} onClick={handleSave}>
+          Save {title}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/types/contract.ts
+++ b/admin-ui/src/types/contract.ts
@@ -1,0 +1,79 @@
+export type ContractType = 'SALE' | 'RENT' | 'LEASE'
+export type ContractStatus = 'DRAFT' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED' | 'EXPIRED'
+export type PaymentMethod = 'CASH' | 'BANK_TRANSFER' | 'CHECK' | 'CREDIT_CARD' | 'INSTALLMENT'
+
+export interface Contract {
+  id: string
+  type: ContractType
+  status: ContractStatus
+  propertyId: string
+  property?: { id: string; title: string; address?: string } | null
+  clientId: string
+  client?: { id: string; firstName: string; lastName: string; phone: string; email?: string | null } | null
+  agentId?: string | null
+  agent?: { id: string; name: string } | null
+  startDate: string
+  endDate?: string | null
+  totalAmount: number
+  paymentTerms?: Record<string, unknown> | null
+  documentUrl?: string | null
+  notes?: string | null
+  createdAt: string
+  updatedAt: string
+  _count?: { invoices?: number }
+}
+
+export interface ContractDetail extends Contract {
+  invoices: {
+    id: string
+    amount: number
+    dueDate: string
+    status: string
+    paidDate?: string | null
+    paymentMethod?: string | null
+  }[]
+}
+
+export interface CreateContractPayload {
+  type: ContractType
+  propertyId: string
+  clientId: string
+  agentId?: string
+  startDate: string
+  endDate?: string
+  totalAmount: number
+  paymentTerms?: Record<string, unknown>
+  documentUrl?: string
+  notes?: string
+}
+
+export interface UpdateContractPayload extends Partial<CreateContractPayload> {}
+
+export interface ContractFilter {
+  page?: number
+  pageSize?: number
+  type?: ContractType
+  status?: ContractStatus
+  clientId?: string
+  propertyId?: string
+  agentId?: string
+  dateFrom?: string
+  dateTo?: string
+  sortBy?: 'createdAt' | 'startDate' | 'endDate' | 'totalAmount'
+  sortOrder?: 'asc' | 'desc'
+}
+
+export interface ChangeContractStatusPayload {
+  status: ContractStatus
+}
+
+export interface GenerateInvoicesPayload {
+  paymentMethod?: PaymentMethod
+}
+
+export interface ContractStats {
+  total: number
+  byStatus: Record<ContractStatus, number>
+  byType: Record<ContractType, number>
+  totalValue: number
+}

--- a/admin-ui/src/types/invoice.ts
+++ b/admin-ui/src/types/invoice.ts
@@ -1,0 +1,76 @@
+import type { PaymentMethod } from './contract'
+
+export type InvoiceStatus = 'PENDING' | 'PAID' | 'OVERDUE' | 'CANCELLED' | 'REFUNDED'
+
+export interface Invoice {
+  id: string
+  contractId: string
+  contract?: {
+    id: string
+    type: string
+    property?: { id: string; title: string } | null
+    client?: { id: string; firstName: string; lastName: string } | null
+  } | null
+  amount: number
+  dueDate: string
+  status: InvoiceStatus
+  paidDate?: string | null
+  paymentMethod?: PaymentMethod | null
+  notes?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface InvoiceDetail extends Invoice {
+  contract: {
+    id: string
+    type: string
+    status: string
+    totalAmount: number
+    startDate: string
+    endDate?: string | null
+    property?: { id: string; title: string; address?: string } | null
+    client?: { id: string; firstName: string; lastName: string; phone: string; email?: string | null } | null
+    agent?: { id: string; name: string } | null
+  }
+}
+
+export interface CreateInvoicePayload {
+  contractId: string
+  amount: number
+  dueDate: string
+  notes?: string
+}
+
+export interface UpdateInvoicePayload {
+  amount?: number
+  dueDate?: string
+  notes?: string
+}
+
+export interface InvoiceFilter {
+  page?: number
+  pageSize?: number
+  status?: InvoiceStatus
+  contractId?: string
+  dateFrom?: string
+  dateTo?: string
+  overdue?: string
+  sortBy?: 'createdAt' | 'dueDate' | 'amount'
+  sortOrder?: 'asc' | 'desc'
+}
+
+export interface RecordPaymentPayload {
+  paidDate: string
+  paymentMethod: PaymentMethod
+  notes?: string
+}
+
+export interface InvoiceStats {
+  totalDue: number
+  totalCollected: number
+  totalOverdue: number
+  pendingCount: number
+  overdueCount: number
+  paidCount: number
+}

--- a/admin-ui/src/types/reports.ts
+++ b/admin-ui/src/types/reports.ts
@@ -1,0 +1,135 @@
+// ─── Report Types ─────────────────────────────────────────────────────────
+
+export interface RevenueReportParams {
+  range?: string
+  from?: string
+  to?: string
+  groupBy?: 'day' | 'week' | 'month'
+  type?: string
+  agentId?: string
+}
+
+export interface RevenueReportItem {
+  period: string
+  revenue: number
+  contracts: number
+  avgDealSize: number
+}
+
+export interface RevenueReportResponse {
+  data: RevenueReportItem[]
+  total: number
+  period: { start: string; end: string }
+}
+
+export interface LeadConversionParams {
+  range?: string
+  from?: string
+  to?: string
+  agentId?: string
+  source?: string
+}
+
+export interface LeadConversionItem {
+  source: string
+  total: number
+  converted: number
+  conversionRate: number
+}
+
+export interface LeadConversionResponse {
+  bySource: LeadConversionItem[]
+  overall: {
+    total: number
+    converted: number
+    conversionRate: number
+  }
+  period: { start: string; end: string }
+}
+
+export interface PropertyReportItem {
+  type: string
+  total: number
+  available: number
+  sold: number
+  rented: number
+  avgPrice: number
+}
+
+export interface PropertyReportResponse {
+  byType: PropertyReportItem[]
+  totals: {
+    total: number
+    available: number
+    sold: number
+    rented: number
+  }
+}
+
+// ─── Agent Types ──────────────────────────────────────────────────────────
+
+export interface Agent {
+  id: string
+  authmeId: string
+  email: string
+  firstName: string | null
+  lastName: string | null
+  role: string
+  isActive: boolean
+  lastLoginAt: string | null
+  createdAt: string
+  _count?: {
+    assignedProperties: number
+    assignedClients: number
+    assignedLeads: number
+  }
+}
+
+export interface AgentDetail extends Agent {
+  assignedProperties: {
+    id: string
+    title: string
+    status: string
+    price: number
+    type: string
+  }[]
+  assignedClients: {
+    id: string
+    firstName: string
+    lastName: string
+    email: string
+    phone: string | null
+  }[]
+  assignedLeads: {
+    id: string
+    title: string
+    status: string
+    priority: string
+    source: string | null
+    createdAt: string
+  }[]
+  performance: {
+    totalLeads: number
+    leadsWon: number
+    revenue: number
+    conversionRate: number
+  }
+}
+
+// ─── Settings Types ───────────────────────────────────────────────────────
+
+export interface CompanySettings {
+  name: string
+  address: string
+  phone: string
+  email: string
+  website: string
+  logo?: string
+}
+
+export interface ConfigItem {
+  id: string
+  label: string
+  value: string
+  isActive: boolean
+}

--- a/agent-ui/src/api/clients.ts
+++ b/agent-ui/src/api/clients.ts
@@ -1,0 +1,42 @@
+import apiClient from './client'
+import type {
+  Client,
+  ClientStats,
+  CreateClientPayload,
+  UpdateClientPayload,
+  PaginatedResponse,
+} from '../types'
+
+export interface ClientListParams {
+  page?: number
+  limit?: number
+  search?: string
+  type?: string
+  source?: string
+  assignedAgentId?: string
+  sortBy?: 'createdAt' | 'firstName' | 'lastName'
+  sortOrder?: 'asc' | 'desc'
+}
+
+export const clientsApi = {
+  list: (params?: ClientListParams) =>
+    apiClient.get<PaginatedResponse<Client>>('/api/clients', { params }).then((r) => r.data),
+
+  stats: () =>
+    apiClient.get<ClientStats>('/api/clients/stats').then((r) => r.data),
+
+  get: (id: string) =>
+    apiClient.get<Client>(`/api/clients/${id}`).then((r) => r.data),
+
+  history: (id: string) =>
+    apiClient.get<unknown[]>(`/api/clients/${id}/history`).then((r) => r.data),
+
+  create: (data: CreateClientPayload) =>
+    apiClient.post<Client>('/api/clients', data).then((r) => r.data),
+
+  update: (id: string, data: UpdateClientPayload) =>
+    apiClient.put<Client>(`/api/clients/${id}`, data).then((r) => r.data),
+
+  assign: (id: string, agentId: string) =>
+    apiClient.patch<Client>(`/api/clients/${id}/assign`, { agentId }).then((r) => r.data),
+}

--- a/agent-ui/src/api/leads.ts
+++ b/agent-ui/src/api/leads.ts
@@ -1,0 +1,51 @@
+import apiClient from './client'
+import type {
+  Lead,
+  LeadStats,
+  LeadActivity,
+  CreateLeadPayload,
+  UpdateLeadPayload,
+  PaginatedResponse,
+} from '../types'
+
+export interface LeadListParams {
+  page?: number
+  limit?: number
+  search?: string
+  status?: string
+  priority?: string
+  assignedAgentId?: string
+  dateFrom?: string
+  dateTo?: string
+  sortBy?: 'createdAt' | 'priority' | 'nextFollowUp'
+  sortOrder?: 'asc' | 'desc'
+}
+
+export const leadsApi = {
+  list: (params?: LeadListParams) =>
+    apiClient.get<PaginatedResponse<Lead>>('/api/leads', { params }).then((r) => r.data),
+
+  pipeline: () =>
+    apiClient.get<Record<string, Lead[]>>('/api/leads/pipeline').then((r) => r.data),
+
+  stats: () =>
+    apiClient.get<LeadStats>('/api/leads/stats').then((r) => r.data),
+
+  get: (id: string) =>
+    apiClient.get<Lead>(`/api/leads/${id}`).then((r) => r.data),
+
+  create: (data: CreateLeadPayload) =>
+    apiClient.post<Lead>('/api/leads', data).then((r) => r.data),
+
+  update: (id: string, data: UpdateLeadPayload) =>
+    apiClient.put<Lead>(`/api/leads/${id}`, data).then((r) => r.data),
+
+  changeStatus: (id: string, status: string, notes?: string) =>
+    apiClient.patch<Lead>(`/api/leads/${id}/status`, { status, notes }).then((r) => r.data),
+
+  addActivity: (id: string, type: string, description: string) =>
+    apiClient.post<LeadActivity>(`/api/leads/${id}/activities`, { type, description }).then((r) => r.data),
+
+  getActivities: (id: string, params?: { page?: number; limit?: number }) =>
+    apiClient.get<PaginatedResponse<LeadActivity>>(`/api/leads/${id}/activities`, { params }).then((r) => r.data),
+}

--- a/agent-ui/src/api/properties.ts
+++ b/agent-ui/src/api/properties.ts
@@ -1,0 +1,37 @@
+import apiClient from './client'
+import type {
+  Property,
+  PropertyStats,
+  PropertyStatus,
+  PaginatedResponse,
+} from '../types'
+
+export interface PropertyListParams {
+  page?: number
+  limit?: number
+  search?: string
+  type?: string
+  status?: string
+  minPrice?: number
+  maxPrice?: number
+  minArea?: number
+  maxArea?: number
+  city?: string
+  bedrooms?: number
+  sortBy?: 'createdAt' | 'price' | 'area' | 'title'
+  sortOrder?: 'asc' | 'desc'
+}
+
+export const propertiesApi = {
+  list: (params?: PropertyListParams) =>
+    apiClient.get<PaginatedResponse<Property>>('/api/properties', { params }).then((r) => r.data),
+
+  stats: () =>
+    apiClient.get<PropertyStats>('/api/properties/stats').then((r) => r.data),
+
+  get: (id: string) =>
+    apiClient.get<Property>(`/api/properties/${id}`).then((r) => r.data),
+
+  changeStatus: (id: string, status: PropertyStatus) =>
+    apiClient.patch<Property>(`/api/properties/${id}/status`, { status }).then((r) => r.data),
+}

--- a/agent-ui/src/components/clients/ClientDetailPanel.tsx
+++ b/agent-ui/src/components/clients/ClientDetailPanel.tsx
@@ -1,0 +1,165 @@
+import { useState, useEffect } from 'react'
+import { X, Mail, Phone, User, Tag, Clock } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { cn, formatDate } from '../../utils'
+import { Badge, LoadingSpinner } from '../ui'
+import { LeadStatusBadge } from '../leads/LeadStatusBadge'
+import { clientsApi } from '../../api/clients'
+import type { Client } from '../../types'
+
+interface ClientDetailPanelProps {
+  clientId: string
+  onClose: () => void
+}
+
+export function ClientDetailPanel({ clientId, onClose }: ClientDetailPanelProps) {
+  const [client, setClient] = useState<Client | null>(null)
+  const [history, setHistory] = useState<unknown[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const [clientData, histData] = await Promise.all([
+          clientsApi.get(clientId),
+          clientsApi.history(clientId),
+        ])
+        setClient(clientData)
+        setHistory(histData)
+      } catch {
+        toast.error('Failed to load client details')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetch()
+  }, [clientId])
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div
+        className={cn(
+          'relative w-full max-w-md bg-white dark:bg-gray-800 shadow-xl',
+          'border-l border-gray-200 dark:border-gray-700',
+          'overflow-y-auto p-6',
+        )}
+      >
+        {loading ? (
+          <LoadingSpinner />
+        ) : client ? (
+          <div className="flex flex-col gap-6">
+            {/* Header */}
+            <div className="flex items-start justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                  {client.firstName} {client.lastName}
+                </h2>
+                <Badge
+                  variant={
+                    client.type === 'BUYER' ? 'blue' :
+                    client.type === 'SELLER' ? 'green' :
+                    client.type === 'INVESTOR' ? 'indigo' :
+                    'purple'
+                  }
+                >
+                  {client.type}
+                </Badge>
+              </div>
+              <button
+                onClick={onClose}
+                className="rounded-lg p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            {/* Contact Info */}
+            <div className="flex flex-col gap-2">
+              {client.email && (
+                <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                  <Mail size={14} />
+                  <span>{client.email}</span>
+                </div>
+              )}
+              <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                <Phone size={14} />
+                <span>{client.phone}</span>
+              </div>
+              {client.nationalId && (
+                <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                  <User size={14} />
+                  <span>ID: {client.nationalId}</span>
+                </div>
+              )}
+              <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                <Tag size={14} />
+                <span>Source: {client.source.replace(/_/g, ' ')}</span>
+              </div>
+            </div>
+
+            {client.notes && (
+              <div className="text-sm text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded-lg p-3">
+                {client.notes}
+              </div>
+            )}
+
+            {/* Leads */}
+            {client.leads && client.leads.length > 0 && (
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                  Leads ({client.leads.length})
+                </h3>
+                <div className="flex flex-col gap-2">
+                  {client.leads.map((lead) => (
+                    <div
+                      key={lead.id}
+                      className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 text-sm"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-gray-900 dark:text-gray-100">
+                          {lead.property?.title ?? 'No property'}
+                        </span>
+                        <LeadStatusBadge status={lead.status} />
+                      </div>
+                      <p className="text-xs text-gray-500 mt-1">Created {formatDate(lead.createdAt)}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Interaction History */}
+            {history.length > 0 && (
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                  Recent History
+                </h3>
+                <div className="flex flex-col gap-2">
+                  {history.slice(0, 10).map((item, idx) => {
+                    const entry = item as Record<string, unknown>
+                    return (
+                      <div key={idx} className="flex gap-2 text-sm">
+                        <Clock size={14} className="text-gray-400 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <p className="text-gray-600 dark:text-gray-400">
+                            {String(entry.description ?? entry.type ?? 'Activity')}
+                          </p>
+                          {entry.createdAt && (
+                            <p className="text-xs text-gray-400">{formatDate(String(entry.createdAt))}</p>
+                          )}
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            <p className="text-xs text-gray-400">Created {formatDate(client.createdAt)}</p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/agent-ui/src/components/clients/ClientFilters.tsx
+++ b/agent-ui/src/components/clients/ClientFilters.tsx
@@ -1,0 +1,67 @@
+import { Search } from 'lucide-react'
+import { Input, Select } from '../ui'
+
+interface ClientFiltersProps {
+  search: string
+  onSearchChange: (v: string) => void
+  type: string
+  onTypeChange: (v: string) => void
+  source: string
+  onSourceChange: (v: string) => void
+}
+
+const typeOptions = [
+  { value: 'BUYER', label: 'Buyer' },
+  { value: 'SELLER', label: 'Seller' },
+  { value: 'TENANT', label: 'Tenant' },
+  { value: 'LANDLORD', label: 'Landlord' },
+  { value: 'INVESTOR', label: 'Investor' },
+]
+
+const sourceOptions = [
+  { value: 'REFERRAL', label: 'Referral' },
+  { value: 'WEBSITE', label: 'Website' },
+  { value: 'SOCIAL_MEDIA', label: 'Social Media' },
+  { value: 'WALK_IN', label: 'Walk-in' },
+  { value: 'PHONE', label: 'Phone' },
+  { value: 'ADVERTISEMENT', label: 'Advertisement' },
+  { value: 'OTHER', label: 'Other' },
+]
+
+export function ClientFilters({
+  search,
+  onSearchChange,
+  type,
+  onTypeChange,
+  source,
+  onSourceChange,
+}: ClientFiltersProps) {
+  return (
+    <div className="flex flex-col sm:flex-row gap-3">
+      <div className="flex-1 max-w-xs">
+        <Input
+          placeholder="Search clients..."
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          leftAddon={<Search size={16} />}
+        />
+      </div>
+      <div className="w-40">
+        <Select
+          options={typeOptions}
+          placeholder="All types"
+          value={type}
+          onChange={(e) => onTypeChange(e.target.value)}
+        />
+      </div>
+      <div className="w-40">
+        <Select
+          options={sourceOptions}
+          placeholder="All sources"
+          value={source}
+          onChange={(e) => onSourceChange(e.target.value)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/agent-ui/src/components/clients/ClientForm.tsx
+++ b/agent-ui/src/components/clients/ClientForm.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import { Button, Input, Select, Textarea } from '../ui'
+import { clientsApi } from '../../api/clients'
+import type { CreateClientPayload, ClientType, ClientSource } from '../../types'
+
+interface ClientFormProps {
+  onSuccess: () => void
+  onCancel: () => void
+}
+
+const typeOptions = [
+  { value: 'BUYER', label: 'Buyer' },
+  { value: 'SELLER', label: 'Seller' },
+  { value: 'TENANT', label: 'Tenant' },
+  { value: 'LANDLORD', label: 'Landlord' },
+  { value: 'INVESTOR', label: 'Investor' },
+]
+
+const sourceOptions = [
+  { value: 'REFERRAL', label: 'Referral' },
+  { value: 'WEBSITE', label: 'Website' },
+  { value: 'SOCIAL_MEDIA', label: 'Social Media' },
+  { value: 'WALK_IN', label: 'Walk-in' },
+  { value: 'PHONE', label: 'Phone' },
+  { value: 'ADVERTISEMENT', label: 'Advertisement' },
+  { value: 'OTHER', label: 'Other' },
+]
+
+export function ClientForm({ onSuccess, onCancel }: ClientFormProps) {
+  const [loading, setLoading] = useState(false)
+  const [form, setForm] = useState<CreateClientPayload>({
+    firstName: '',
+    lastName: '',
+    phone: '',
+    type: 'BUYER',
+    source: 'WEBSITE',
+  })
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!form.firstName.trim() || !form.lastName.trim() || !form.phone.trim()) {
+      toast.error('First name, last name, and phone are required')
+      return
+    }
+    setLoading(true)
+    try {
+      await clientsApi.create(form)
+      toast.success('Client created successfully')
+      onSuccess()
+    } catch {
+      toast.error('Failed to create client')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3">
+        <Input
+          label="First Name"
+          required
+          value={form.firstName}
+          onChange={(e) => setForm({ ...form, firstName: e.target.value })}
+        />
+        <Input
+          label="Last Name"
+          required
+          value={form.lastName}
+          onChange={(e) => setForm({ ...form, lastName: e.target.value })}
+        />
+      </div>
+      <Input
+        label="Phone"
+        required
+        value={form.phone}
+        onChange={(e) => setForm({ ...form, phone: e.target.value })}
+        placeholder="+20..."
+      />
+      <Input
+        label="Email"
+        type="email"
+        value={form.email ?? ''}
+        onChange={(e) => setForm({ ...form, email: e.target.value || undefined })}
+      />
+      <Input
+        label="National ID"
+        value={form.nationalId ?? ''}
+        onChange={(e) => setForm({ ...form, nationalId: e.target.value || undefined })}
+      />
+      <div className="grid grid-cols-2 gap-3">
+        <Select
+          label="Type"
+          required
+          options={typeOptions}
+          value={form.type}
+          onChange={(e) => setForm({ ...form, type: e.target.value as ClientType })}
+        />
+        <Select
+          label="Source"
+          required
+          options={sourceOptions}
+          value={form.source}
+          onChange={(e) => setForm({ ...form, source: e.target.value as ClientSource })}
+        />
+      </div>
+      <Textarea
+        label="Notes"
+        value={form.notes ?? ''}
+        onChange={(e) => setForm({ ...form, notes: e.target.value || undefined })}
+        rows={3}
+      />
+      <div className="flex justify-end gap-2 pt-2">
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" loading={loading}>
+          Create Client
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/agent-ui/src/components/clients/ClientTable.tsx
+++ b/agent-ui/src/components/clients/ClientTable.tsx
@@ -1,0 +1,97 @@
+import { DataTable } from '../ui/DataTable'
+import { Badge } from '../ui/Badge'
+import { formatDate } from '../../utils'
+import type { Client, Column } from '../../types'
+
+interface ClientTableProps {
+  data: Client[]
+  loading: boolean
+  page: number
+  totalPages: number
+  onPageChange: (page: number) => void
+  sortBy: string
+  sortOrder: 'asc' | 'desc'
+  onSort: (key: string) => void
+  onRowClick: (client: Client) => void
+}
+
+const typeVariant: Record<string, 'blue' | 'green' | 'purple' | 'orange' | 'indigo'> = {
+  BUYER: 'blue',
+  SELLER: 'green',
+  TENANT: 'purple',
+  LANDLORD: 'orange',
+  INVESTOR: 'indigo',
+}
+
+const columns: Column<Client>[] = [
+  {
+    key: 'firstName',
+    header: 'Name',
+    sortable: true,
+    render: (_v, row) => (
+      <span className="font-medium">{row.firstName} {row.lastName}</span>
+    ),
+  },
+  {
+    key: 'email',
+    header: 'Email',
+    render: (_v, row) => row.email ?? '-',
+  },
+  {
+    key: 'phone',
+    header: 'Phone',
+  },
+  {
+    key: 'type',
+    header: 'Type',
+    render: (_v, row) => (
+      <Badge variant={typeVariant[row.type] ?? 'gray'}>{row.type}</Badge>
+    ),
+  },
+  {
+    key: 'source',
+    header: 'Source',
+    render: (_v, row) => row.source.replace(/_/g, ' '),
+  },
+  {
+    key: '_count',
+    header: 'Leads',
+    render: (_v, row) => row._count?.leads ?? 0,
+  },
+  {
+    key: 'createdAt',
+    header: 'Created',
+    sortable: true,
+    render: (_v, row) => formatDate(row.createdAt),
+  },
+]
+
+export function ClientTable({
+  data,
+  loading,
+  page,
+  totalPages,
+  onPageChange,
+  sortBy,
+  sortOrder,
+  onSort,
+  onRowClick,
+}: ClientTableProps) {
+  return (
+    <DataTable<Client>
+      columns={columns}
+      data={data}
+      loading={loading}
+      page={page}
+      totalPages={totalPages}
+      onPageChange={onPageChange}
+      sortBy={sortBy}
+      sortOrder={sortOrder}
+      onSort={onSort}
+      onRowClick={onRowClick}
+      rowKey={(row) => row.id}
+      emptyTitle="No clients found"
+      emptyDescription="Try adjusting your filters or add a new client."
+    />
+  )
+}

--- a/agent-ui/src/components/clients/index.ts
+++ b/agent-ui/src/components/clients/index.ts
@@ -1,0 +1,4 @@
+export { ClientFilters } from './ClientFilters'
+export { ClientTable } from './ClientTable'
+export { ClientDetailPanel } from './ClientDetailPanel'
+export { ClientForm } from './ClientForm'

--- a/agent-ui/src/components/leads/LeadActivityForm.tsx
+++ b/agent-ui/src/components/leads/LeadActivityForm.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import { Button, Select, Textarea } from '../ui'
+import { leadsApi } from '../../api/leads'
+
+interface LeadActivityFormProps {
+  leadId: string
+  onSuccess: () => void
+}
+
+const activityTypes = [
+  { value: 'CALL', label: 'Call' },
+  { value: 'EMAIL', label: 'Email' },
+  { value: 'MEETING', label: 'Meeting' },
+  { value: 'NOTE', label: 'Note' },
+  { value: 'VIEWING', label: 'Viewing' },
+  { value: 'FOLLOW_UP', label: 'Follow-up' },
+]
+
+export function LeadActivityForm({ leadId, onSuccess }: LeadActivityFormProps) {
+  const [loading, setLoading] = useState(false)
+  const [type, setType] = useState('CALL')
+  const [description, setDescription] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!description.trim()) {
+      toast.error('Description is required')
+      return
+    }
+    setLoading(true)
+    try {
+      await leadsApi.addActivity(leadId, type, description)
+      toast.success('Activity logged')
+      setDescription('')
+      onSuccess()
+    } catch {
+      toast.error('Failed to log activity')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <Select
+        label="Activity Type"
+        options={activityTypes}
+        value={type}
+        onChange={(e) => setType(e.target.value)}
+      />
+      <Textarea
+        label="Description"
+        required
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        rows={2}
+        placeholder="Describe the activity..."
+      />
+      <div className="flex justify-end">
+        <Button type="submit" size="sm" loading={loading}>
+          Log Activity
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/agent-ui/src/components/leads/LeadDetailPanel.tsx
+++ b/agent-ui/src/components/leads/LeadDetailPanel.tsx
@@ -1,0 +1,206 @@
+import { useState, useEffect } from 'react'
+import { X, User, Building2, Calendar, Clock, Tag } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { cn, formatDate, formatCurrency } from '../../utils'
+import { Button, Badge, LoadingSpinner, Select } from '../ui'
+import { LeadStatusBadge } from './LeadStatusBadge'
+import { LeadActivityForm } from './LeadActivityForm'
+import { leadsApi } from '../../api/leads'
+import type { Lead, LeadActivity, LeadStatus } from '../../types'
+
+interface LeadDetailPanelProps {
+  leadId: string
+  onClose: () => void
+  onUpdated: () => void
+}
+
+const VALID_TRANSITIONS: Record<LeadStatus, LeadStatus[]> = {
+  NEW: ['CONTACTED', 'LOST'],
+  CONTACTED: ['QUALIFIED', 'LOST'],
+  QUALIFIED: ['PROPOSAL', 'LOST'],
+  PROPOSAL: ['NEGOTIATION', 'LOST'],
+  NEGOTIATION: ['WON', 'LOST'],
+  WON: [],
+  LOST: ['NEW'],
+}
+
+export function LeadDetailPanel({ leadId, onClose, onUpdated }: LeadDetailPanelProps) {
+  const [lead, setLead] = useState<Lead | null>(null)
+  const [activities, setActivities] = useState<LeadActivity[]>([])
+  const [loading, setLoading] = useState(true)
+  const [statusChanging, setStatusChanging] = useState(false)
+
+  const fetchLead = async () => {
+    try {
+      const [leadData, actData] = await Promise.all([
+        leadsApi.get(leadId),
+        leadsApi.getActivities(leadId, { limit: 20 }),
+      ])
+      setLead(leadData)
+      setActivities(actData.data)
+    } catch {
+      toast.error('Failed to load lead details')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchLead()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [leadId])
+
+  const handleStatusChange = async (newStatus: string) => {
+    setStatusChanging(true)
+    try {
+      await leadsApi.changeStatus(leadId, newStatus)
+      toast.success(`Status changed to ${newStatus}`)
+      await fetchLead()
+      onUpdated()
+    } catch {
+      toast.error('Failed to change status')
+    } finally {
+      setStatusChanging(false)
+    }
+  }
+
+  if (loading) return <SlideOver onClose={onClose}><LoadingSpinner /></SlideOver>
+  if (!lead) return null
+
+  const transitions = VALID_TRANSITIONS[lead.status] ?? []
+
+  return (
+    <SlideOver onClose={onClose}>
+      <div className="flex flex-col gap-6">
+        {/* Header */}
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Lead Details</h2>
+            <div className="flex items-center gap-2 mt-1">
+              <LeadStatusBadge status={lead.status} />
+              <Badge variant={lead.priority === 'URGENT' ? 'red' : lead.priority === 'HIGH' ? 'orange' : 'gray'}>
+                {lead.priority}
+              </Badge>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Status Change */}
+        {transitions.length > 0 && (
+          <div>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 block mb-1">
+              Change Status
+            </label>
+            <div className="flex gap-2">
+              <Select
+                options={transitions.map((s) => ({ value: s, label: s }))}
+                placeholder="Select status..."
+                onChange={(e) => { if (e.target.value) handleStatusChange(e.target.value) }}
+                disabled={statusChanging}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Client Info */}
+        {lead.client && (
+          <InfoSection icon={User} title="Client">
+            <p className="text-sm text-gray-900 dark:text-gray-100">{lead.client.firstName} {lead.client.lastName}</p>
+            {lead.client.email && <p className="text-xs text-gray-500">{lead.client.email}</p>}
+            <p className="text-xs text-gray-500">{lead.client.phone}</p>
+          </InfoSection>
+        )}
+
+        {/* Property Info */}
+        {lead.property && (
+          <InfoSection icon={Building2} title="Property">
+            <p className="text-sm text-gray-900 dark:text-gray-100">{lead.property.title}</p>
+            <p className="text-xs text-gray-500">{formatCurrency(lead.property.price)}</p>
+          </InfoSection>
+        )}
+
+        {/* Lead Details */}
+        <InfoSection icon={Tag} title="Details">
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            <span className="text-gray-500">Source</span>
+            <span className="text-gray-900 dark:text-gray-100">{lead.source.replace(/_/g, ' ')}</span>
+            {lead.budget != null && (
+              <>
+                <span className="text-gray-500">Budget</span>
+                <span className="text-gray-900 dark:text-gray-100">{formatCurrency(lead.budget)}</span>
+              </>
+            )}
+            <span className="text-gray-500">Created</span>
+            <span className="text-gray-900 dark:text-gray-100">{formatDate(lead.createdAt)}</span>
+          </div>
+        </InfoSection>
+
+        {lead.nextFollowUp && (
+          <InfoSection icon={Calendar} title="Next Follow-up">
+            <p className="text-sm text-gray-900 dark:text-gray-100">{formatDate(lead.nextFollowUp)}</p>
+          </InfoSection>
+        )}
+
+        {lead.notes && (
+          <div className="text-sm text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded-lg p-3">
+            {lead.notes}
+          </div>
+        )}
+
+        {/* Log Activity */}
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">Log Activity</h3>
+          <LeadActivityForm leadId={leadId} onSuccess={fetchLead} />
+        </div>
+
+        {/* Activity Timeline */}
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Recent Activity</h3>
+          {activities.length === 0 ? (
+            <p className="text-sm text-gray-400">No activities yet.</p>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {activities.map((a) => (
+                <div key={a.id} className="flex gap-3">
+                  <div className="flex-shrink-0 mt-0.5">
+                    <Clock size={14} className="text-gray-400" />
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <Badge variant="gray">{a.type}</Badge>
+                      <span className="text-xs text-gray-400">{formatDate(a.createdAt)}</span>
+                    </div>
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mt-0.5">{a.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </SlideOver>
+  )
+}
+
+function SlideOver({ onClose, children }: { onClose: () => void; children: React.ReactNode }) {
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div
+        className={cn(
+          'relative w-full max-w-md bg-white dark:bg-gray-800 shadow-xl',
+          'border-l border-gray-200 dark:border-gray-700',
+          'overflow-y-auto p-6',
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/agent-ui/src/components/leads/LeadFilters.tsx
+++ b/agent-ui/src/components/leads/LeadFilters.tsx
@@ -1,0 +1,66 @@
+import { Search } from 'lucide-react'
+import { Input, Select } from '../ui'
+
+interface LeadFiltersProps {
+  search: string
+  onSearchChange: (v: string) => void
+  status: string
+  onStatusChange: (v: string) => void
+  priority: string
+  onPriorityChange: (v: string) => void
+}
+
+const statusOptions = [
+  { value: 'NEW', label: 'New' },
+  { value: 'CONTACTED', label: 'Contacted' },
+  { value: 'QUALIFIED', label: 'Qualified' },
+  { value: 'PROPOSAL', label: 'Proposal' },
+  { value: 'NEGOTIATION', label: 'Negotiation' },
+  { value: 'WON', label: 'Won' },
+  { value: 'LOST', label: 'Lost' },
+]
+
+const priorityOptions = [
+  { value: 'LOW', label: 'Low' },
+  { value: 'MEDIUM', label: 'Medium' },
+  { value: 'HIGH', label: 'High' },
+  { value: 'URGENT', label: 'Urgent' },
+]
+
+export function LeadFilters({
+  search,
+  onSearchChange,
+  status,
+  onStatusChange,
+  priority,
+  onPriorityChange,
+}: LeadFiltersProps) {
+  return (
+    <div className="flex flex-col sm:flex-row gap-3">
+      <div className="flex-1 max-w-xs">
+        <Input
+          placeholder="Search leads..."
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          leftAddon={<Search size={16} />}
+        />
+      </div>
+      <div className="w-40">
+        <Select
+          options={statusOptions}
+          placeholder="All statuses"
+          value={status}
+          onChange={(e) => onStatusChange(e.target.value)}
+        />
+      </div>
+      <div className="w-40">
+        <Select
+          options={priorityOptions}
+          placeholder="All priorities"
+          value={priority}
+          onChange={(e) => onPriorityChange(e.target.value)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/agent-ui/src/components/leads/LeadForm.tsx
+++ b/agent-ui/src/components/leads/LeadForm.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import { Button, Input, Select, Textarea } from '../ui'
+import { leadsApi } from '../../api/leads'
+import type { CreateLeadPayload } from '../../types'
+
+interface LeadFormProps {
+  onSuccess: () => void
+  onCancel: () => void
+}
+
+const sourceOptions = [
+  { value: 'REFERRAL', label: 'Referral' },
+  { value: 'WEBSITE', label: 'Website' },
+  { value: 'SOCIAL_MEDIA', label: 'Social Media' },
+  { value: 'WALK_IN', label: 'Walk-in' },
+  { value: 'PHONE', label: 'Phone' },
+  { value: 'ADVERTISEMENT', label: 'Advertisement' },
+  { value: 'OTHER', label: 'Other' },
+]
+
+const priorityOptions = [
+  { value: 'LOW', label: 'Low' },
+  { value: 'MEDIUM', label: 'Medium' },
+  { value: 'HIGH', label: 'High' },
+  { value: 'URGENT', label: 'Urgent' },
+]
+
+export function LeadForm({ onSuccess, onCancel }: LeadFormProps) {
+  const [loading, setLoading] = useState(false)
+  const [form, setForm] = useState<CreateLeadPayload>({
+    clientId: '',
+    source: 'WEBSITE',
+    priority: 'MEDIUM',
+  })
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!form.clientId.trim()) {
+      toast.error('Client ID is required')
+      return
+    }
+    setLoading(true)
+    try {
+      await leadsApi.create(form)
+      toast.success('Lead created successfully')
+      onSuccess()
+    } catch {
+      toast.error('Failed to create lead')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <Input
+        label="Client ID"
+        required
+        value={form.clientId}
+        onChange={(e) => setForm({ ...form, clientId: e.target.value })}
+        placeholder="Enter client ID"
+      />
+      <Input
+        label="Property ID"
+        value={form.propertyId ?? ''}
+        onChange={(e) => setForm({ ...form, propertyId: e.target.value || undefined })}
+        placeholder="Enter property ID (optional)"
+      />
+      <div className="grid grid-cols-2 gap-3">
+        <Select
+          label="Source"
+          options={sourceOptions}
+          value={form.source ?? ''}
+          onChange={(e) => setForm({ ...form, source: e.target.value as CreateLeadPayload['source'] })}
+        />
+        <Select
+          label="Priority"
+          options={priorityOptions}
+          value={form.priority ?? ''}
+          onChange={(e) => setForm({ ...form, priority: e.target.value as CreateLeadPayload['priority'] })}
+        />
+      </div>
+      <Input
+        label="Budget"
+        type="number"
+        value={form.budget ?? ''}
+        onChange={(e) => setForm({ ...form, budget: e.target.value ? Number(e.target.value) : undefined })}
+        placeholder="0"
+      />
+      <Input
+        label="Next Follow-up"
+        type="datetime-local"
+        value={form.nextFollowUp ?? ''}
+        onChange={(e) => setForm({ ...form, nextFollowUp: e.target.value || undefined })}
+      />
+      <Textarea
+        label="Notes"
+        value={form.notes ?? ''}
+        onChange={(e) => setForm({ ...form, notes: e.target.value || undefined })}
+        rows={3}
+        placeholder="Additional notes..."
+      />
+      <div className="flex justify-end gap-2 pt-2">
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" loading={loading}>
+          Create Lead
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/agent-ui/src/components/leads/LeadKanban.tsx
+++ b/agent-ui/src/components/leads/LeadKanban.tsx
@@ -1,0 +1,101 @@
+import { cn } from '../../utils'
+import { LeadStatusBadge } from './LeadStatusBadge'
+import { Badge } from '../ui/Badge'
+import { LoadingSpinner } from '../ui/LoadingSpinner'
+import type { Lead, LeadStatus } from '../../types'
+
+interface LeadKanbanProps {
+  pipeline: Record<string, Lead[]> | null
+  loading: boolean
+  onLeadClick: (lead: Lead) => void
+  onStatusChange: (leadId: string, newStatus: LeadStatus) => void
+}
+
+const STATUSES: { key: LeadStatus; label: string; color: string }[] = [
+  { key: 'NEW', label: 'New', color: 'border-t-blue-500' },
+  { key: 'CONTACTED', label: 'Contacted', color: 'border-t-indigo-500' },
+  { key: 'QUALIFIED', label: 'Qualified', color: 'border-t-purple-500' },
+  { key: 'PROPOSAL', label: 'Proposal', color: 'border-t-orange-500' },
+  { key: 'NEGOTIATION', label: 'Negotiation', color: 'border-t-yellow-500' },
+  { key: 'WON', label: 'Won', color: 'border-t-green-500' },
+  { key: 'LOST', label: 'Lost', color: 'border-t-red-500' },
+]
+
+const VALID_TRANSITIONS: Record<LeadStatus, LeadStatus[]> = {
+  NEW: ['CONTACTED', 'LOST'],
+  CONTACTED: ['QUALIFIED', 'LOST'],
+  QUALIFIED: ['PROPOSAL', 'LOST'],
+  PROPOSAL: ['NEGOTIATION', 'LOST'],
+  NEGOTIATION: ['WON', 'LOST'],
+  WON: [],
+  LOST: ['NEW'],
+}
+
+export function LeadKanban({ pipeline, loading, onLeadClick, onStatusChange }: LeadKanbanProps) {
+  if (loading) return <LoadingSpinner message="Loading pipeline..." />
+
+  return (
+    <div className="flex gap-3 overflow-x-auto pb-4">
+      {STATUSES.map((s) => {
+        const leads = pipeline?.[s.key] ?? []
+        return (
+          <div
+            key={s.key}
+            className={cn(
+              'flex-shrink-0 w-64 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50',
+              'border-t-4',
+              s.color,
+            )}
+          >
+            <div className="px-3 py-2 flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">{s.label}</h3>
+              <span className="text-xs text-gray-500 bg-gray-200 dark:bg-gray-700 rounded-full px-2 py-0.5">
+                {leads.length}
+              </span>
+            </div>
+            <div className="px-2 pb-2 flex flex-col gap-2 max-h-[60vh] overflow-y-auto">
+              {leads.map((lead) => (
+                <div
+                  key={lead.id}
+                  onClick={() => onLeadClick(lead)}
+                  className="rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-3 cursor-pointer hover:shadow-md transition-shadow"
+                >
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                    {lead.client ? `${lead.client.firstName} ${lead.client.lastName}` : 'Unknown'}
+                  </p>
+                  {lead.property && (
+                    <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">
+                      {lead.property.title}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-1 mt-2">
+                    <LeadStatusBadge status={lead.status} />
+                    <Badge variant={lead.priority === 'URGENT' ? 'red' : lead.priority === 'HIGH' ? 'orange' : 'gray'}>
+                      {lead.priority}
+                    </Badge>
+                  </div>
+                  {VALID_TRANSITIONS[lead.status].length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {VALID_TRANSITIONS[lead.status].map((nextStatus) => (
+                        <button
+                          key={nextStatus}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onStatusChange(lead.id, nextStatus)
+                          }}
+                          className="text-[10px] px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-indigo-100 hover:text-indigo-700 dark:hover:bg-indigo-900/30 dark:hover:text-indigo-400 transition-colors"
+                        >
+                          → {nextStatus}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/agent-ui/src/components/leads/LeadStatusBadge.tsx
+++ b/agent-ui/src/components/leads/LeadStatusBadge.tsx
@@ -1,0 +1,17 @@
+import { Badge } from '../ui/Badge'
+import type { LeadStatus } from '../../types'
+
+const statusConfig: Record<LeadStatus, { label: string; variant: 'gray' | 'blue' | 'indigo' | 'purple' | 'orange' | 'green' | 'red' }> = {
+  NEW: { label: 'New', variant: 'blue' },
+  CONTACTED: { label: 'Contacted', variant: 'indigo' },
+  QUALIFIED: { label: 'Qualified', variant: 'purple' },
+  PROPOSAL: { label: 'Proposal', variant: 'orange' },
+  NEGOTIATION: { label: 'Negotiation', variant: 'orange' },
+  WON: { label: 'Won', variant: 'green' },
+  LOST: { label: 'Lost', variant: 'red' },
+}
+
+export function LeadStatusBadge({ status }: { status: LeadStatus }) {
+  const config = statusConfig[status]
+  return <Badge variant={config.variant}>{config.label}</Badge>
+}

--- a/agent-ui/src/components/leads/LeadTable.tsx
+++ b/agent-ui/src/components/leads/LeadTable.tsx
@@ -1,0 +1,99 @@
+import { DataTable } from '../ui/DataTable'
+import { Badge } from '../ui/Badge'
+import { LeadStatusBadge } from './LeadStatusBadge'
+import { formatDate } from '../../utils'
+import type { Lead, Column } from '../../types'
+
+interface LeadTableProps {
+  data: Lead[]
+  loading: boolean
+  page: number
+  totalPages: number
+  onPageChange: (page: number) => void
+  sortBy: string
+  sortOrder: 'asc' | 'desc'
+  onSort: (key: string) => void
+  onRowClick: (lead: Lead) => void
+}
+
+const priorityVariant: Record<string, 'gray' | 'blue' | 'orange' | 'red'> = {
+  LOW: 'gray',
+  MEDIUM: 'blue',
+  HIGH: 'orange',
+  URGENT: 'red',
+}
+
+const columns: Column<Lead>[] = [
+  {
+    key: 'client',
+    header: 'Client',
+    render: (_v, row) =>
+      row.client
+        ? `${row.client.firstName} ${row.client.lastName}`
+        : '-',
+  },
+  {
+    key: 'property',
+    header: 'Property',
+    render: (_v, row) => row.property?.title ?? '-',
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    render: (_v, row) => <LeadStatusBadge status={row.status} />,
+  },
+  {
+    key: 'priority',
+    header: 'Priority',
+    render: (_v, row) => (
+      <Badge variant={priorityVariant[row.priority] ?? 'gray'}>{row.priority}</Badge>
+    ),
+  },
+  {
+    key: 'source',
+    header: 'Source',
+    render: (_v, row) => row.source.replace(/_/g, ' '),
+  },
+  {
+    key: 'nextFollowUp',
+    header: 'Follow-up',
+    sortable: true,
+    render: (_v, row) => (row.nextFollowUp ? formatDate(row.nextFollowUp) : '-'),
+  },
+  {
+    key: 'createdAt',
+    header: 'Created',
+    sortable: true,
+    render: (_v, row) => formatDate(row.createdAt),
+  },
+]
+
+export function LeadTable({
+  data,
+  loading,
+  page,
+  totalPages,
+  onPageChange,
+  sortBy,
+  sortOrder,
+  onSort,
+  onRowClick,
+}: LeadTableProps) {
+  return (
+    <DataTable<Lead>
+      columns={columns}
+      data={data}
+      loading={loading}
+      page={page}
+      totalPages={totalPages}
+      onPageChange={onPageChange}
+      sortBy={sortBy}
+      sortOrder={sortOrder}
+      onSort={onSort}
+      onRowClick={onRowClick}
+      rowKey={(row) => row.id}
+      emptyTitle="No leads found"
+      emptyDescription="Try adjusting your filters or add a new lead."
+    />
+  )
+}

--- a/agent-ui/src/components/leads/index.ts
+++ b/agent-ui/src/components/leads/index.ts
@@ -1,0 +1,7 @@
+export { LeadFilters } from './LeadFilters'
+export { LeadTable } from './LeadTable'
+export { LeadKanban } from './LeadKanban'
+export { LeadDetailPanel } from './LeadDetailPanel'
+export { LeadForm } from './LeadForm'
+export { LeadActivityForm } from './LeadActivityForm'
+export { LeadStatusBadge } from './LeadStatusBadge'

--- a/agent-ui/src/components/properties/PropertyFilters.tsx
+++ b/agent-ui/src/components/properties/PropertyFilters.tsx
@@ -1,0 +1,129 @@
+import { Search } from 'lucide-react'
+import { Input, Select } from '../ui'
+
+interface PropertyFiltersProps {
+  search: string
+  onSearchChange: (v: string) => void
+  type: string
+  onTypeChange: (v: string) => void
+  status: string
+  onStatusChange: (v: string) => void
+  minPrice: string
+  onMinPriceChange: (v: string) => void
+  maxPrice: string
+  onMaxPriceChange: (v: string) => void
+  bedrooms: string
+  onBedroomsChange: (v: string) => void
+  city: string
+  onCityChange: (v: string) => void
+}
+
+const typeOptions = [
+  { value: 'APARTMENT', label: 'Apartment' },
+  { value: 'VILLA', label: 'Villa' },
+  { value: 'OFFICE', label: 'Office' },
+  { value: 'SHOP', label: 'Shop' },
+  { value: 'LAND', label: 'Land' },
+  { value: 'BUILDING', label: 'Building' },
+  { value: 'CHALET', label: 'Chalet' },
+  { value: 'STUDIO', label: 'Studio' },
+  { value: 'DUPLEX', label: 'Duplex' },
+  { value: 'PENTHOUSE', label: 'Penthouse' },
+]
+
+const statusOptions = [
+  { value: 'AVAILABLE', label: 'Available' },
+  { value: 'RESERVED', label: 'Reserved' },
+  { value: 'SOLD', label: 'Sold' },
+  { value: 'RENTED', label: 'Rented' },
+  { value: 'OFF_MARKET', label: 'Off Market' },
+]
+
+const bedroomOptions = [
+  { value: '1', label: '1 BR' },
+  { value: '2', label: '2 BR' },
+  { value: '3', label: '3 BR' },
+  { value: '4', label: '4 BR' },
+  { value: '5', label: '5+ BR' },
+]
+
+export function PropertyFilters({
+  search,
+  onSearchChange,
+  type,
+  onTypeChange,
+  status,
+  onStatusChange,
+  minPrice,
+  onMinPriceChange,
+  maxPrice,
+  onMaxPriceChange,
+  bedrooms,
+  onBedroomsChange,
+  city,
+  onCityChange,
+}: PropertyFiltersProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex-1 max-w-xs">
+          <Input
+            placeholder="Search properties..."
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            leftAddon={<Search size={16} />}
+          />
+        </div>
+        <div className="w-36">
+          <Select
+            options={typeOptions}
+            placeholder="All types"
+            value={type}
+            onChange={(e) => onTypeChange(e.target.value)}
+          />
+        </div>
+        <div className="w-36">
+          <Select
+            options={statusOptions}
+            placeholder="All statuses"
+            value={status}
+            onChange={(e) => onStatusChange(e.target.value)}
+          />
+        </div>
+        <div className="w-32">
+          <Select
+            options={bedroomOptions}
+            placeholder="Bedrooms"
+            value={bedrooms}
+            onChange={(e) => onBedroomsChange(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="w-36">
+          <Input
+            placeholder="Min price"
+            type="number"
+            value={minPrice}
+            onChange={(e) => onMinPriceChange(e.target.value)}
+          />
+        </div>
+        <div className="w-36">
+          <Input
+            placeholder="Max price"
+            type="number"
+            value={maxPrice}
+            onChange={(e) => onMaxPriceChange(e.target.value)}
+          />
+        </div>
+        <div className="w-36">
+          <Input
+            placeholder="City"
+            value={city}
+            onChange={(e) => onCityChange(e.target.value)}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/agent-ui/src/components/properties/PropertyStatusBadge.tsx
+++ b/agent-ui/src/components/properties/PropertyStatusBadge.tsx
@@ -1,0 +1,15 @@
+import { Badge } from '../ui/Badge'
+import type { PropertyStatus } from '../../types'
+
+const statusConfig: Record<PropertyStatus, { label: string; variant: 'green' | 'yellow' | 'red' | 'blue' | 'gray' }> = {
+  AVAILABLE: { label: 'Available', variant: 'green' },
+  RESERVED: { label: 'Reserved', variant: 'yellow' },
+  SOLD: { label: 'Sold', variant: 'red' },
+  RENTED: { label: 'Rented', variant: 'blue' },
+  OFF_MARKET: { label: 'Off Market', variant: 'gray' },
+}
+
+export function PropertyStatusBadge({ status }: { status: PropertyStatus }) {
+  const config = statusConfig[status]
+  return <Badge variant={config.variant}>{config.label}</Badge>
+}

--- a/agent-ui/src/components/ui/Badge.tsx
+++ b/agent-ui/src/components/ui/Badge.tsx
@@ -1,0 +1,36 @@
+import { cn } from '../../utils'
+
+type BadgeVariant = 'gray' | 'red' | 'yellow' | 'green' | 'blue' | 'indigo' | 'purple' | 'pink' | 'orange' | 'sky'
+
+interface BadgeProps {
+  children: React.ReactNode
+  variant?: BadgeVariant
+  className?: string
+}
+
+const variantClasses: Record<BadgeVariant, string> = {
+  gray: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  red: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400',
+  yellow: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-400',
+  green: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400',
+  blue: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400',
+  indigo: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-400',
+  purple: 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-400',
+  pink: 'bg-pink-100 text-pink-700 dark:bg-pink-900/40 dark:text-pink-400',
+  orange: 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-400',
+  sky: 'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-400',
+}
+
+export function Badge({ children, variant = 'gray', className }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+        variantClasses[variant],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}

--- a/agent-ui/src/components/ui/DataTable.tsx
+++ b/agent-ui/src/components/ui/DataTable.tsx
@@ -1,0 +1,112 @@
+import { ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'
+import { cn } from '../../utils'
+import { Pagination } from './Pagination'
+import { EmptyState } from './EmptyState'
+import { LoadingSpinner } from './LoadingSpinner'
+import type { Column } from '../../types'
+
+interface DataTableProps<T> {
+  columns: Column<T>[]
+  data: T[]
+  loading?: boolean
+  page?: number
+  totalPages?: number
+  onPageChange?: (page: number) => void
+  sortBy?: string
+  sortOrder?: 'asc' | 'desc'
+  onSort?: (key: string) => void
+  onRowClick?: (row: T) => void
+  rowKey?: (row: T) => string
+  emptyTitle?: string
+  emptyDescription?: string
+  className?: string
+}
+
+export function DataTable<T extends Record<string, unknown>>({
+  columns,
+  data,
+  loading,
+  page,
+  totalPages,
+  onPageChange,
+  sortBy,
+  sortOrder,
+  onSort,
+  onRowClick,
+  rowKey,
+  emptyTitle,
+  emptyDescription,
+  className,
+}: DataTableProps<T>) {
+  if (loading) return <LoadingSpinner message="Loading data..." />
+
+  if (!data.length) {
+    return <EmptyState title={emptyTitle} description={emptyDescription} />
+  }
+
+  const getSortIcon = (key: string) => {
+    if (sortBy !== key) return <ArrowUpDown size={14} className="text-gray-400" />
+    return sortOrder === 'asc' ? (
+      <ArrowUp size={14} className="text-indigo-600 dark:text-indigo-400" />
+    ) : (
+      <ArrowDown size={14} className="text-indigo-600 dark:text-indigo-400" />
+    )
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      <div className="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-800/50">
+            <tr>
+              {columns.map((col) => (
+                <th
+                  key={col.key}
+                  className={cn(
+                    'px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider',
+                    col.sortable && 'cursor-pointer select-none hover:text-gray-700 dark:hover:text-gray-200',
+                  )}
+                  style={col.width ? { width: col.width } : undefined}
+                  onClick={col.sortable && onSort ? () => onSort(col.key) : undefined}
+                >
+                  <div className="flex items-center gap-1">
+                    {col.header}
+                    {col.sortable && getSortIcon(col.key)}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-800">
+            {data.map((row, idx) => (
+              <tr
+                key={rowKey ? rowKey(row) : idx}
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+                className={cn(
+                  'transition-colors',
+                  onRowClick && 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50',
+                )}
+              >
+                {columns.map((col) => (
+                  <td
+                    key={col.key}
+                    className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap"
+                  >
+                    {col.render
+                      ? col.render(row[col.key], row)
+                      : (String(row[col.key] ?? '-'))}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {page && totalPages && onPageChange && (
+        <div className="flex justify-center">
+          <Pagination page={page} totalPages={totalPages} onPageChange={onPageChange} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/agent-ui/src/components/ui/EmptyState.tsx
+++ b/agent-ui/src/components/ui/EmptyState.tsx
@@ -1,0 +1,34 @@
+import { Inbox } from 'lucide-react'
+import { cn } from '../../utils'
+
+interface EmptyStateProps {
+  icon?: React.ComponentType<{ size?: number; className?: string }>
+  title?: string
+  description?: string
+  action?: React.ReactNode
+  className?: string
+}
+
+export function EmptyState({
+  icon: Icon = Inbox,
+  title = 'No data found',
+  description = 'There are no items to display at this time.',
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center py-12 text-center',
+        className,
+      )}
+    >
+      <div className="rounded-full bg-gray-100 dark:bg-gray-700 p-4 mb-4">
+        <Icon size={32} className="text-gray-400 dark:text-gray-500" />
+      </div>
+      <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">{title}</h3>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 max-w-sm">{description}</p>
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  )
+}

--- a/agent-ui/src/components/ui/Modal.tsx
+++ b/agent-ui/src/components/ui/Modal.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react'
+import { X } from 'lucide-react'
+import { cn } from '../../utils'
+
+interface ModalProps {
+  open: boolean
+  onClose: () => void
+  title?: string
+  children: React.ReactNode
+  size?: 'sm' | 'md' | 'lg' | 'xl'
+  className?: string
+}
+
+const sizeClasses = {
+  sm: 'max-w-md',
+  md: 'max-w-lg',
+  lg: 'max-w-2xl',
+  xl: 'max-w-4xl',
+}
+
+export function Modal({ open, onClose, title, children, size = 'md', className }: ModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = ''
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === overlayRef.current) onClose()
+      }}
+    >
+      <div
+        className={cn(
+          'w-full rounded-xl bg-white dark:bg-gray-800 shadow-xl',
+          'border border-gray-200 dark:border-gray-700',
+          'max-h-[90vh] flex flex-col',
+          sizeClasses[size],
+          className,
+        )}
+      >
+        {title && (
+          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h2>
+            <button
+              onClick={onClose}
+              className="rounded-lg p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:text-gray-300 dark:hover:bg-gray-700 transition-colors"
+            >
+              <X size={20} />
+            </button>
+          </div>
+        )}
+        <div className="overflow-y-auto p-6">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/agent-ui/src/components/ui/Pagination.tsx
+++ b/agent-ui/src/components/ui/Pagination.tsx
@@ -1,0 +1,62 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { cn } from '../../utils'
+
+interface PaginationProps {
+  page: number
+  totalPages: number
+  onPageChange: (page: number) => void
+  className?: string
+}
+
+export function Pagination({ page, totalPages, onPageChange, className }: PaginationProps) {
+  if (totalPages <= 1) return null
+
+  const pages: (number | 'ellipsis')[] = []
+  for (let i = 1; i <= totalPages; i++) {
+    if (i === 1 || i === totalPages || (i >= page - 1 && i <= page + 1)) {
+      pages.push(i)
+    } else if (pages[pages.length - 1] !== 'ellipsis') {
+      pages.push('ellipsis')
+    }
+  }
+
+  const btnBase =
+    'inline-flex items-center justify-center h-8 min-w-[2rem] px-2 text-sm rounded-lg transition-colors'
+
+  return (
+    <div className={cn('flex items-center gap-1', className)}>
+      <button
+        onClick={() => onPageChange(page - 1)}
+        disabled={page <= 1}
+        className={cn(btnBase, 'text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed')}
+      >
+        <ChevronLeft size={16} />
+      </button>
+      {pages.map((p, idx) =>
+        p === 'ellipsis' ? (
+          <span key={`e-${idx}`} className="px-1 text-gray-400 text-sm">...</span>
+        ) : (
+          <button
+            key={p}
+            onClick={() => onPageChange(p)}
+            className={cn(
+              btnBase,
+              p === page
+                ? 'bg-indigo-600 text-white dark:bg-indigo-500'
+                : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700',
+            )}
+          >
+            {p}
+          </button>
+        ),
+      )}
+      <button
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages}
+        className={cn(btnBase, 'text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed')}
+      >
+        <ChevronRight size={16} />
+      </button>
+    </div>
+  )
+}

--- a/agent-ui/src/components/ui/Select.tsx
+++ b/agent-ui/src/components/ui/Select.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { cn } from '../../utils'
+
+interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  label?: string
+  error?: string
+  options: { value: string; label: string }[]
+  placeholder?: string
+}
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ label, error, options, placeholder, required, className, id, ...props }, ref) => {
+    const selectId = id ?? label?.toLowerCase().replace(/\s+/g, '-')
+
+    return (
+      <div className="flex flex-col gap-1">
+        {label && (
+          <label
+            htmlFor={selectId}
+            className="text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {label}
+            {required && <span className="text-red-500 ml-1">*</span>}
+          </label>
+        )}
+        <select
+          ref={ref}
+          id={selectId}
+          required={required}
+          className={cn(
+            'w-full rounded-lg border bg-white text-gray-900 text-sm',
+            'px-3 py-2',
+            'transition-colors duration-150',
+            'focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent',
+            'disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed',
+            'dark:bg-gray-800 dark:text-gray-100',
+            error
+              ? 'border-red-400 focus:ring-red-400 dark:border-red-500'
+              : 'border-gray-300 dark:border-gray-600',
+            className,
+          )}
+          {...props}
+        >
+          {placeholder && <option value="">{placeholder}</option>}
+          {options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        {error && <p className="text-xs text-red-500">{error}</p>}
+      </div>
+    )
+  },
+)
+
+Select.displayName = 'Select'

--- a/agent-ui/src/components/ui/Textarea.tsx
+++ b/agent-ui/src/components/ui/Textarea.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { cn } from '../../utils'
+
+interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: string
+  error?: string
+}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ label, error, required, className, id, ...props }, ref) => {
+    const textareaId = id ?? label?.toLowerCase().replace(/\s+/g, '-')
+
+    return (
+      <div className="flex flex-col gap-1">
+        {label && (
+          <label
+            htmlFor={textareaId}
+            className="text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {label}
+            {required && <span className="text-red-500 ml-1">*</span>}
+          </label>
+        )}
+        <textarea
+          ref={ref}
+          id={textareaId}
+          required={required}
+          className={cn(
+            'w-full rounded-lg border bg-white text-gray-900 text-sm',
+            'px-3 py-2 placeholder:text-gray-400',
+            'transition-colors duration-150',
+            'focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent',
+            'disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed',
+            'dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500',
+            error
+              ? 'border-red-400 focus:ring-red-400 dark:border-red-500'
+              : 'border-gray-300 dark:border-gray-600',
+            className,
+          )}
+          {...props}
+        />
+        {error && <p className="text-xs text-red-500">{error}</p>}
+      </div>
+    )
+  },
+)
+
+Textarea.displayName = 'Textarea'


### PR DESCRIPTION
## Summary
- **Reports page** (`/reports`) with three tabs: Revenue (area + bar charts, summary stats), Lead Conversion (horizontal bar, pie, detail table), and Properties (bar, pie, detail table). Date range filter and CSV export for revenue and leads.
- **Agents list page** (`/agents`) showing agent cards with avatar, status badge, and workload stats (properties, clients, leads counts). Includes search and pagination.
- **Agent detail page** (`/agents/:id`) with performance stats (leads won, revenue, conversion rate), and tables for assigned properties, clients, and leads with links to their detail pages.
- **Settings page** (`/settings`) with Company Info form, Property Types config, and Lead Sources config — all with CRUD and save/persist via API.
- API layer: `api/reports.ts`, `api/agents.ts`, `api/settings.ts` with typed request/response interfaces.
- React Query hooks: `useReports.ts`, `useAgents.ts`.
- Updated `App.tsx` routes: `/reports`, `/agents`, `/agents/:id`, `/settings`.

Closes #19

## Test plan
- [ ] Navigate to `/reports` and verify all three tabs render charts correctly
- [ ] Test date range filter changes data across revenue and lead tabs
- [ ] Test CSV export buttons (both server-side and client-side fallback)
- [ ] Navigate to `/agents` and verify agent cards with workload stats
- [ ] Search agents by name/email
- [ ] Click an agent card to view `/agents/:id` detail page
- [ ] Verify performance stats and assigned entities tables on detail page
- [ ] Navigate to `/settings` and test all three tabs
- [ ] Verify company info form saves correctly
- [ ] Test adding/removing/editing property types and lead sources

Generated with [Claude Code](https://claude.com/claude-code)