### PR TITLE
feat(agent-ui): Contracts & Activities (#23)

### DIFF
--- a/agent-ui/src/api/activities.ts
+++ b/agent-ui/src/api/activities.ts
@@ -1,0 +1,39 @@
+import apiClient from './client'
+import type {
+  Activity,
+  ActivityFilter,
+  ActivityEntityType,
+  PaginatedResponse,
+} from '../types'
+
+const BASE = '/api/activities'
+
+export const activitiesApi = {
+  list(filter?: ActivityFilter) {
+    return apiClient
+      .get<PaginatedResponse<Activity>>(BASE, { params: filter })
+      .then((r) => r.data)
+  },
+
+  recent(limit = 20) {
+    return apiClient
+      .get<Activity[]>(`${BASE}/recent`, { params: { limit } })
+      .then((r) => r.data)
+  },
+
+  byEntity(type: ActivityEntityType, id: string, filter?: ActivityFilter) {
+    return apiClient
+      .get<PaginatedResponse<Activity>>(`${BASE}/entity/${type}/${id}`, {
+        params: filter,
+      })
+      .then((r) => r.data)
+  },
+
+  byUser(userId: string, filter?: ActivityFilter) {
+    return apiClient
+      .get<PaginatedResponse<Activity>>(`${BASE}/user/${userId}`, {
+        params: filter,
+      })
+      .then((r) => r.data)
+  },
+}

--- a/agent-ui/src/api/contracts.ts
+++ b/agent-ui/src/api/contracts.ts
@@ -1,0 +1,39 @@
+import apiClient from './client'
+import type {
+  Contract,
+  ContractDetail,
+  ContractFilter,
+  ContractStats,
+  Invoice,
+  PaginatedResponse,
+} from '../types'
+
+const BASE = '/api/contracts'
+
+export const contractsApi = {
+  list(filter?: ContractFilter) {
+    return apiClient
+      .get<PaginatedResponse<Contract>>(BASE, { params: filter })
+      .then((r) => r.data)
+  },
+
+  getById(id: string) {
+    return apiClient.get<ContractDetail>(`${BASE}/${id}`).then((r) => r.data)
+  },
+
+  getStats() {
+    return apiClient.get<ContractStats>(`${BASE}/stats`).then((r) => r.data)
+  },
+
+  getExpiring(days = 30) {
+    return apiClient
+      .get<Contract[]>(`${BASE}/expiring`, { params: { days } })
+      .then((r) => r.data)
+  },
+
+  getInvoices(id: string) {
+    return apiClient
+      .get<Invoice[]>(`${BASE}/${id}/invoices`)
+      .then((r) => r.data)
+  },
+}

--- a/agent-ui/src/components/ActivityLog.tsx
+++ b/agent-ui/src/components/ActivityLog.tsx
@@ -1,0 +1,155 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  Clock,
+  Building2,
+  Users,
+  UserCheck,
+  FileText,
+  Receipt,
+  ArrowRight,
+} from 'lucide-react'
+import { activitiesApi } from '../api/activities'
+import { LoadingSpinner } from './ui/LoadingSpinner'
+import { EmptyState } from './ui/EmptyState'
+import { Badge } from './ui/Badge'
+import { cn } from '../utils'
+import type { Activity, ActivityEntityType } from '../types'
+
+// ─── helpers ──────────────────────────────────────────────────────
+
+const ENTITY_ICON: Record<ActivityEntityType, React.ComponentType<{ size?: number; className?: string }>> = {
+  PROPERTY: Building2,
+  CLIENT: Users,
+  LEAD: UserCheck,
+  CONTRACT: FileText,
+  INVOICE: Receipt,
+}
+
+const ENTITY_COLOR: Record<ActivityEntityType, string> = {
+  PROPERTY: 'bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-400',
+  CLIENT: 'bg-green-100 text-green-600 dark:bg-green-900/40 dark:text-green-400',
+  LEAD: 'bg-yellow-100 text-yellow-600 dark:bg-yellow-900/40 dark:text-yellow-400',
+  CONTRACT: 'bg-indigo-100 text-indigo-600 dark:bg-indigo-900/40 dark:text-indigo-400',
+  INVOICE: 'bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-400',
+}
+
+const TYPE_BADGE_VARIANT: Record<string, 'green' | 'blue' | 'red' | 'yellow' | 'gray' | 'indigo'> = {
+  CREATE: 'green',
+  UPDATE: 'blue',
+  DELETE: 'red',
+  STATUS_CHANGE: 'yellow',
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(new Date(iso))
+}
+
+// ─── single timeline item ─────────────────────────────────────────
+
+function ActivityItem({ activity }: { activity: Activity }) {
+  const Icon = ENTITY_ICON[activity.entityType] ?? FileText
+  const colorClass = ENTITY_COLOR[activity.entityType] ?? 'bg-gray-100 text-gray-600'
+  const badgeVariant = TYPE_BADGE_VARIANT[activity.type] ?? 'gray'
+
+  return (
+    <li className="relative flex gap-3 pb-6 last:pb-0 group">
+      {/* vertical line */}
+      <div className="absolute left-[17px] top-9 bottom-0 w-px bg-gray-200 dark:bg-gray-700 group-last:hidden" />
+
+      {/* icon */}
+      <div className={cn('flex items-center justify-center w-9 h-9 rounded-full shrink-0 z-10', colorClass)}>
+        <Icon size={16} />
+      </div>
+
+      {/* content */}
+      <div className="flex-1 min-w-0 pt-0.5">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge variant={badgeVariant}>{activity.type.replace('_', ' ')}</Badge>
+          <span className="text-xs text-gray-400 dark:text-gray-500 flex items-center gap-1">
+            <Clock size={12} />
+            {relativeTime(activity.createdAt)}
+          </span>
+        </div>
+        <p className="mt-1 text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+          {activity.description}
+        </p>
+        {activity.user && (
+          <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+            by {activity.user.name}
+          </p>
+        )}
+      </div>
+    </li>
+  )
+}
+
+// ─── main component ───────────────────────────────────────────────
+
+interface ActivityLogProps {
+  /** If provided, fetch activities for this specific entity */
+  entityType?: ActivityEntityType
+  entityId?: string
+  /** Max items to show */
+  limit?: number
+  className?: string
+}
+
+export function ActivityLog({ entityType, entityId, limit = 20, className }: ActivityLogProps) {
+  const queryKey = entityType && entityId
+    ? ['activities', 'entity', entityType, entityId]
+    : ['activities', 'recent']
+
+  const { data, isLoading, error } = useQuery({
+    queryKey,
+    queryFn: () => {
+      if (entityType && entityId) {
+        return activitiesApi.byEntity(entityType, entityId, { pageSize: limit })
+      }
+      return activitiesApi.recent(limit)
+    },
+  })
+
+  if (isLoading) return <LoadingSpinner message="Loading activities..." />
+
+  if (error) {
+    return (
+      <div className="text-center py-8 text-sm text-red-500">
+        Failed to load activities.
+      </div>
+    )
+  }
+
+  const activities: Activity[] = Array.isArray(data) ? data : (data as { data: Activity[] })?.data ?? []
+
+  if (!activities.length) {
+    return (
+      <EmptyState
+        title="No activities yet"
+        description="Activities will appear here as actions are performed."
+        className={className}
+      />
+    )
+  }
+
+  return (
+    <div className={cn('rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5', className)}>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
+        <ArrowRight size={16} className="text-indigo-500" />
+        Activity Timeline
+      </h3>
+      <ul className="space-y-0">
+        {activities.map((a) => (
+          <ActivityItem key={a.id} activity={a} />
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/agent-ui/src/components/QuickLogActivity.tsx
+++ b/agent-ui/src/components/QuickLogActivity.tsx
@@ -1,0 +1,150 @@
+import { useState, useRef, useEffect } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Plus, Phone, Users as UsersIcon, StickyNote, X } from 'lucide-react'
+import toast from 'react-hot-toast'
+import apiClient from '../api/client'
+import { useAuth } from '../context/AuthContext'
+import { Button } from './ui/Button'
+import { Textarea } from './ui/Textarea'
+import { cn } from '../utils'
+
+type QuickType = 'CALL' | 'MEETING' | 'NOTE'
+
+const QUICK_TYPES: { value: QuickType; label: string; icon: React.ComponentType<{ size?: number; className?: string }> }[] = [
+  { value: 'CALL', label: 'Call', icon: Phone },
+  { value: 'MEETING', label: 'Meeting', icon: UsersIcon },
+  { value: 'NOTE', label: 'Note', icon: StickyNote },
+]
+
+interface QuickLogActivityProps {
+  /** Pre-fill entity context if logging from a detail page */
+  entityType?: string
+  entityId?: string
+  className?: string
+}
+
+export function QuickLogActivity({ entityType, entityId, className }: QuickLogActivityProps) {
+  const [open, setOpen] = useState(false)
+  const [selected, setSelected] = useState<QuickType>('CALL')
+  const [description, setDescription] = useState('')
+  const panelRef = useRef<HTMLDivElement>(null)
+  const { user } = useAuth()
+  const queryClient = useQueryClient()
+
+  // close on outside click
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const mutation = useMutation({
+    mutationFn: (payload: {
+      type: string
+      description: string
+      entityType: string
+      entityId: string
+      performedBy: string
+    }) => apiClient.post('/api/activities', payload).then((r) => r.data),
+    onSuccess: () => {
+      toast.success('Activity logged!')
+      setDescription('')
+      setOpen(false)
+      // Invalidate activity queries so lists refresh
+      queryClient.invalidateQueries({ queryKey: ['activities'] })
+    },
+    onError: () => {
+      toast.error('Failed to log activity.')
+    },
+  })
+
+  const handleSubmit = () => {
+    if (!description.trim()) {
+      toast.error('Please enter a description.')
+      return
+    }
+    mutation.mutate({
+      type: selected,
+      description: description.trim(),
+      entityType: entityType ?? 'LEAD',
+      entityId: entityId ?? '',
+      performedBy: user?.id ?? '',
+    })
+  }
+
+  return (
+    <div className={cn('fixed bottom-6 right-6 z-40', className)} ref={panelRef}>
+      {/* Expanded panel */}
+      {open && (
+        <div className="mb-3 w-80 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-xl p-4 animate-in fade-in slide-in-from-bottom-2">
+          <div className="flex items-center justify-between mb-3">
+            <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              Quick Log Activity
+            </h4>
+            <button
+              onClick={() => setOpen(false)}
+              className="p-1 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:text-gray-300 dark:hover:bg-gray-700 transition-colors"
+            >
+              <X size={16} />
+            </button>
+          </div>
+
+          {/* Type selector */}
+          <div className="flex gap-2 mb-3">
+            {QUICK_TYPES.map(({ value, label, icon: Icon }) => (
+              <button
+                key={value}
+                onClick={() => setSelected(value)}
+                className={cn(
+                  'flex-1 flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors',
+                  selected === value
+                    ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-400'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600',
+                )}
+              >
+                <Icon size={14} />
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {/* Description */}
+          <Textarea
+            placeholder={`Describe the ${selected.toLowerCase()}...`}
+            rows={3}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+
+          <Button
+            className="w-full mt-3"
+            size="sm"
+            onClick={handleSubmit}
+            loading={mutation.isPending}
+          >
+            Log {selected.charAt(0) + selected.slice(1).toLowerCase()}
+          </Button>
+        </div>
+      )}
+
+      {/* FAB */}
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        className={cn(
+          'flex items-center justify-center w-14 h-14 rounded-full shadow-lg transition-all duration-200',
+          'bg-indigo-600 text-white hover:bg-indigo-700 hover:scale-105',
+          'focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2',
+          open && 'rotate-45',
+        )}
+        title="Quick log activity"
+      >
+        <Plus size={24} />
+      </button>
+    </div>
+  )
+}

--- a/agent-ui/src/pages/ActivitiesPage.tsx
+++ b/agent-ui/src/pages/ActivitiesPage.tsx
@@ -1,15 +1,175 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Activity as ActivityIcon, Clock, Filter } from 'lucide-react'
+import { activitiesApi } from '../api/activities'
+import { ActivityLog } from '../components/ActivityLog'
+import { QuickLogActivity } from '../components/QuickLogActivity'
+import { Select } from '../components/ui/Select'
+import { LoadingSpinner } from '../components/ui/LoadingSpinner'
+import { Pagination } from '../components/ui/Pagination'
+import { EmptyState } from '../components/ui/EmptyState'
+import { Badge } from '../components/ui/Badge'
+import { cn, formatDate } from '../utils'
+import { useAuth } from '../context/AuthContext'
+import type { Activity, ActivityEntityType } from '../types'
+
+// ─── constants ────────────────────────────────────────────────────
+
+const ENTITY_TYPE_OPTIONS = [
+  { value: '', label: 'All Entities' },
+  { value: 'PROPERTY', label: 'Property' },
+  { value: 'CLIENT', label: 'Client' },
+  { value: 'LEAD', label: 'Lead' },
+  { value: 'CONTRACT', label: 'Contract' },
+  { value: 'INVOICE', label: 'Invoice' },
+]
+
+const ACTIVITY_TYPE_OPTIONS = [
+  { value: '', label: 'All Actions' },
+  { value: 'CREATE', label: 'Create' },
+  { value: 'UPDATE', label: 'Update' },
+  { value: 'DELETE', label: 'Delete' },
+  { value: 'STATUS_CHANGE', label: 'Status Change' },
+  { value: 'CALL', label: 'Call' },
+  { value: 'MEETING', label: 'Meeting' },
+  { value: 'NOTE', label: 'Note' },
+]
+
+const SCOPE_OPTIONS = [
+  { value: 'all', label: 'All Activities' },
+  { value: 'mine', label: 'My Activities' },
+]
+
+// ─── page ─────────────────────────────────────────────────────────
+
 export default function ActivitiesPage() {
+  const { user } = useAuth()
+  const [page, setPage] = useState(1)
+  const [entityType, setEntityType] = useState('')
+  const [activityType, setActivityType] = useState('')
+  const [scope, setScope] = useState('all')
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['activities', page, entityType, activityType, scope, user?.id],
+    queryFn: () => {
+      if (scope === 'mine' && user?.id) {
+        return activitiesApi.byUser(user.id, {
+          page,
+          pageSize: 15,
+          entityType: (entityType || undefined) as ActivityEntityType | undefined,
+          type: activityType || undefined,
+        })
+      }
+      return activitiesApi.list({
+        page,
+        pageSize: 15,
+        entityType: (entityType || undefined) as ActivityEntityType | undefined,
+        type: activityType || undefined,
+      })
+    },
+  })
+
+  const activities: Activity[] = data?.data ?? []
+  const totalPages = data?.totalPages ?? 1
+
   return (
     <div className="flex flex-col gap-6">
+      {/* Header */}
       <div>
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Activities</h1>
         <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          Log and review your daily activities.
+          Log and review your daily activities across all entities.
         </p>
       </div>
-      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-8 text-center">
-        <p className="text-gray-400 dark:text-gray-500 text-sm">Activity log coming soon…</p>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Filter size={16} className="text-gray-400" />
+        <div className="w-40">
+          <Select
+            options={SCOPE_OPTIONS}
+            value={scope}
+            onChange={(e) => { setScope(e.target.value); setPage(1) }}
+          />
+        </div>
+        <div className="w-40">
+          <Select
+            options={ENTITY_TYPE_OPTIONS}
+            value={entityType}
+            onChange={(e) => { setEntityType(e.target.value); setPage(1) }}
+          />
+        </div>
+        <div className="w-40">
+          <Select
+            options={ACTIVITY_TYPE_OPTIONS}
+            value={activityType}
+            onChange={(e) => { setActivityType(e.target.value); setPage(1) }}
+          />
+        </div>
       </div>
+
+      {/* Activity list */}
+      {isLoading ? (
+        <LoadingSpinner message="Loading activities..." />
+      ) : activities.length === 0 ? (
+        <EmptyState
+          icon={ActivityIcon}
+          title="No activities found"
+          description="Activities will appear here as actions are performed in the system."
+        />
+      ) : (
+        <>
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            {activities.map((activity) => (
+              <div
+                key={activity.id}
+                className="flex items-start gap-4 px-5 py-4 hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors"
+              >
+                {/* Icon */}
+                <div className="flex items-center justify-center w-9 h-9 rounded-full bg-indigo-100 dark:bg-indigo-900/40 text-indigo-600 dark:text-indigo-400 shrink-0 mt-0.5">
+                  <ActivityIcon size={16} />
+                </div>
+
+                {/* Content */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <Badge variant="gray">{activity.entityType}</Badge>
+                    <Badge variant={
+                      activity.type === 'CREATE' ? 'green'
+                        : activity.type === 'DELETE' ? 'red'
+                        : activity.type === 'STATUS_CHANGE' ? 'yellow'
+                        : 'blue'
+                    }>
+                      {activity.type.replace('_', ' ')}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-sm text-gray-700 dark:text-gray-300">
+                    {activity.description}
+                  </p>
+                  <div className="mt-1 flex items-center gap-3 text-xs text-gray-400 dark:text-gray-500">
+                    <span className="flex items-center gap-1">
+                      <Clock size={12} />
+                      {formatDate(activity.createdAt)}
+                    </span>
+                    {activity.user && (
+                      <span>by {activity.user.name}</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex justify-center">
+              <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Floating action button */}
+      <QuickLogActivity />
     </div>
   )
 }

--- a/agent-ui/src/pages/ContractDetailPage.tsx
+++ b/agent-ui/src/pages/ContractDetailPage.tsx
@@ -1,0 +1,236 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  ArrowLeft,
+  FileText,
+  Building2,
+  Users,
+  Calendar,
+  DollarSign,
+  CheckCircle2,
+  Clock,
+  AlertCircle,
+  XCircle,
+} from 'lucide-react'
+import { contractsApi } from '../api/contracts'
+import { ActivityLog } from '../components/ActivityLog'
+import { Badge } from '../components/ui/Badge'
+import { Button } from '../components/ui/Button'
+import { LoadingSpinner } from '../components/ui/LoadingSpinner'
+import { formatCurrency, formatDate } from '../utils'
+import type { ContractStatus, Invoice, InvoiceStatus } from '../types'
+
+// ─── helpers ──────────────────────────────────────────────────────
+
+const STATUS_BADGE: Record<ContractStatus, 'gray' | 'green' | 'blue' | 'red' | 'yellow'> = {
+  DRAFT: 'gray',
+  ACTIVE: 'green',
+  COMPLETED: 'blue',
+  CANCELLED: 'red',
+  EXPIRED: 'yellow',
+}
+
+const INVOICE_BADGE: Record<InvoiceStatus, 'yellow' | 'green' | 'red' | 'gray'> = {
+  PENDING: 'yellow',
+  PAID: 'green',
+  OVERDUE: 'red',
+  CANCELLED: 'gray',
+}
+
+const INVOICE_ICON: Record<InvoiceStatus, React.ComponentType<{ size?: number; className?: string }>> = {
+  PENDING: Clock,
+  PAID: CheckCircle2,
+  OVERDUE: AlertCircle,
+  CANCELLED: XCircle,
+}
+
+// ─── component ────────────────────────────────────────────────────
+
+interface ContractDetailPageProps {
+  contractId: string
+  onBack: () => void
+}
+
+export default function ContractDetailPage({ contractId, onBack }: ContractDetailPageProps) {
+  const { data: contract, isLoading, error } = useQuery({
+    queryKey: ['contracts', contractId],
+    queryFn: () => contractsApi.getById(contractId),
+    enabled: !!contractId,
+  })
+
+  if (isLoading) return <LoadingSpinner message="Loading contract..." />
+
+  if (error || !contract) {
+    return (
+      <div className="flex flex-col items-center py-16 gap-4">
+        <p className="text-sm text-red-500">Failed to load contract details.</p>
+        <Button variant="secondary" size="sm" onClick={onBack}>
+          Back to Contracts
+        </Button>
+      </div>
+    )
+  }
+
+  const invoices: Invoice[] = contract.invoices ?? []
+  const paidTotal = invoices
+    .filter((i) => i.status === 'PAID')
+    .reduce((sum, i) => sum + i.amount, 0)
+  const pendingTotal = invoices
+    .filter((i) => i.status === 'PENDING' || i.status === 'OVERDUE')
+    .reduce((sum, i) => sum + i.amount, 0)
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="sm" onClick={onBack} leftIcon={<ArrowLeft size={16} />}>
+          Back
+        </Button>
+        <div className="flex-1">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              Contract Details
+            </h1>
+            <Badge variant={STATUS_BADGE[contract.status]}>{contract.status}</Badge>
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+            {contract.type} contract &middot; Created {formatDate(contract.createdAt)}
+          </p>
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {/* Property */}
+        <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+          <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400 mb-2">
+            <Building2 size={16} />
+            <span className="text-xs font-medium uppercase tracking-wide">Property</span>
+          </div>
+          <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            {contract.property?.title ?? 'N/A'}
+          </p>
+          {contract.property?.address && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              {contract.property.address}
+            </p>
+          )}
+        </div>
+
+        {/* Client */}
+        <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+          <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400 mb-2">
+            <Users size={16} />
+            <span className="text-xs font-medium uppercase tracking-wide">Client</span>
+          </div>
+          <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            {contract.client
+              ? `${contract.client.firstName} ${contract.client.lastName}`
+              : 'N/A'}
+          </p>
+          {contract.client?.phone && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              {contract.client.phone}
+            </p>
+          )}
+        </div>
+
+        {/* Financial */}
+        <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+          <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400 mb-2">
+            <DollarSign size={16} />
+            <span className="text-xs font-medium uppercase tracking-wide">Financials</span>
+          </div>
+          <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            {formatCurrency(contract.totalAmount)}
+          </p>
+          <div className="flex gap-3 mt-1">
+            <span className="text-xs text-green-600 dark:text-green-400">
+              Paid: {formatCurrency(paidTotal)}
+            </span>
+            <span className="text-xs text-yellow-600 dark:text-yellow-400">
+              Pending: {formatCurrency(pendingTotal)}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Date range */}
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 flex items-center gap-6 flex-wrap">
+        <div className="flex items-center gap-2">
+          <Calendar size={16} className="text-gray-400" />
+          <span className="text-sm text-gray-600 dark:text-gray-400">Start:</span>
+          <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+            {formatDate(contract.startDate)}
+          </span>
+        </div>
+        {contract.endDate && (
+          <div className="flex items-center gap-2">
+            <Calendar size={16} className="text-gray-400" />
+            <span className="text-sm text-gray-600 dark:text-gray-400">End:</span>
+            <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+              {formatDate(contract.endDate)}
+            </span>
+          </div>
+        )}
+        {contract.notes && (
+          <p className="basis-full text-sm text-gray-500 dark:text-gray-400 mt-2 italic">
+            {contract.notes}
+          </p>
+        )}
+      </div>
+
+      {/* Invoice schedule */}
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+        <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center gap-2">
+          <FileText size={16} className="text-indigo-500" />
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Invoice Schedule
+          </h2>
+          <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto">
+            {invoices.length} invoice{invoices.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+
+        {invoices.length === 0 ? (
+          <div className="px-5 py-8 text-center text-sm text-gray-400 dark:text-gray-500">
+            No invoices generated yet.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-200 dark:divide-gray-700">
+            {invoices.map((inv) => {
+              const InvIcon = INVOICE_ICON[inv.status as InvoiceStatus] ?? Clock
+              return (
+                <div
+                  key={inv.id}
+                  className="flex items-center gap-4 px-5 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                >
+                  <InvIcon size={18} className="text-gray-400 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                      {formatCurrency(inv.amount)}
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      Due {formatDate(inv.dueDate)}
+                      {inv.paidDate && ` — Paid ${formatDate(inv.paidDate)}`}
+                    </p>
+                  </div>
+                  <Badge variant={INVOICE_BADGE[inv.status as InvoiceStatus] ?? 'gray'}>
+                    {inv.status}
+                  </Badge>
+                  {inv.paymentMethod && (
+                    <span className="text-xs text-gray-400 dark:text-gray-500 hidden sm:inline">
+                      {inv.paymentMethod.replace('_', ' ')}
+                    </span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Activity timeline */}
+      <ActivityLog entityType="CONTRACT" entityId={contractId} />
+    </div>
+  )
+}

--- a/agent-ui/src/pages/ContractsPage.tsx
+++ b/agent-ui/src/pages/ContractsPage.tsx
@@ -1,15 +1,253 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { FileText, Eye, Calendar, DollarSign } from 'lucide-react'
+import { contractsApi } from '../api/contracts'
+import { Badge } from '../components/ui/Badge'
+import { DataTable } from '../components/ui/DataTable'
+import { Select } from '../components/ui/Select'
+import { StatsCard } from '../components/ui/StatsCard'
+import { formatCurrency, formatDate } from '../utils'
+import type { Column, Contract, ContractStatus, ContractType } from '../types'
+import ContractDetailPage from './ContractDetailPage'
+
+// ─── helpers ──────────────────────────────────────────────────────
+
+const STATUS_BADGE: Record<ContractStatus, 'gray' | 'green' | 'blue' | 'red' | 'yellow'> = {
+  DRAFT: 'gray',
+  ACTIVE: 'green',
+  COMPLETED: 'blue',
+  CANCELLED: 'red',
+  EXPIRED: 'yellow',
+}
+
+const TYPE_BADGE: Record<ContractType, 'indigo' | 'purple' | 'sky'> = {
+  SALE: 'indigo',
+  RENT: 'purple',
+  LEASE: 'sky',
+}
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All Statuses' },
+  { value: 'DRAFT', label: 'Draft' },
+  { value: 'ACTIVE', label: 'Active' },
+  { value: 'COMPLETED', label: 'Completed' },
+  { value: 'CANCELLED', label: 'Cancelled' },
+  { value: 'EXPIRED', label: 'Expired' },
+]
+
+const TYPE_OPTIONS = [
+  { value: '', label: 'All Types' },
+  { value: 'SALE', label: 'Sale' },
+  { value: 'RENT', label: 'Rent' },
+  { value: 'LEASE', label: 'Lease' },
+]
+
+const SORT_OPTIONS = [
+  { value: 'createdAt', label: 'Date Created' },
+  { value: 'startDate', label: 'Start Date' },
+  { value: 'totalAmount', label: 'Total Amount' },
+]
+
+// ─── columns ──────────────────────────────────────────────────────
+
+const columns: Column<Contract>[] = [
+  {
+    key: 'type',
+    header: 'Type',
+    render: (_v, row) => (
+      <Badge variant={TYPE_BADGE[row.type] ?? 'gray'}>
+        {row.type}
+      </Badge>
+    ),
+  },
+  {
+    key: 'property',
+    header: 'Property',
+    render: (_v, row) => (
+      <span className="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[200px] block">
+        {row.property?.title ?? '-'}
+      </span>
+    ),
+  },
+  {
+    key: 'client',
+    header: 'Client',
+    render: (_v, row) =>
+      row.client ? `${row.client.firstName} ${row.client.lastName}` : '-',
+  },
+  {
+    key: 'totalAmount',
+    header: 'Amount',
+    sortable: true,
+    render: (_v, row) => (
+      <span className="font-semibold text-gray-900 dark:text-gray-100">
+        {formatCurrency(row.totalAmount)}
+      </span>
+    ),
+  },
+  {
+    key: 'startDate',
+    header: 'Start',
+    sortable: true,
+    render: (_v, row) => formatDate(row.startDate),
+  },
+  {
+    key: 'endDate',
+    header: 'End',
+    render: (_v, row) => (row.endDate ? formatDate(row.endDate) : '-'),
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    render: (_v, row) => (
+      <Badge variant={STATUS_BADGE[row.status] ?? 'gray'}>
+        {row.status}
+      </Badge>
+    ),
+  },
+  {
+    key: 'actions',
+    header: '',
+    width: '48px',
+    render: () => (
+      <Eye size={16} className="text-gray-400 hover:text-indigo-500 transition-colors" />
+    ),
+  },
+]
+
+// ─── page ─────────────────────────────────────────────────────────
+
 export default function ContractsPage() {
+  const [page, setPage] = useState(1)
+  const [statusFilter, setStatusFilter] = useState('')
+  const [typeFilter, setTypeFilter] = useState('')
+  const [sortBy, setSortBy] = useState<string>('createdAt')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['contracts', page, statusFilter, typeFilter, sortBy, sortOrder],
+    queryFn: () =>
+      contractsApi.list({
+        page,
+        pageSize: 10,
+        status: (statusFilter || undefined) as ContractStatus | undefined,
+        type: (typeFilter || undefined) as ContractType | undefined,
+        sortBy: sortBy as 'createdAt' | 'startDate' | 'totalAmount',
+        sortOrder,
+      }),
+  })
+
+  const { data: stats } = useQuery({
+    queryKey: ['contracts', 'stats'],
+    queryFn: () => contractsApi.getStats(),
+  })
+
+  const handleSort = (key: string) => {
+    if (sortBy === key) {
+      setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortBy(key)
+      setSortOrder('desc')
+    }
+  }
+
+  // ── detail view ──
+  if (selectedId) {
+    return (
+      <ContractDetailPage
+        contractId={selectedId}
+        onBack={() => setSelectedId(null)}
+      />
+    )
+  }
+
   return (
     <div className="flex flex-col gap-6">
+      {/* Header */}
       <div>
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Contracts</h1>
         <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          Review and manage your active contracts.
+          Review your active contracts linked to your clients and properties.
         </p>
       </div>
-      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-8 text-center">
-        <p className="text-gray-400 dark:text-gray-500 text-sm">Contracts list coming soon…</p>
+
+      {/* Stats */}
+      {stats && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <StatsCard
+            title="Total Contracts"
+            value={stats.total}
+            icon={FileText}
+          />
+          <StatsCard
+            title="Active"
+            value={stats.byStatus?.ACTIVE ?? 0}
+            icon={Calendar}
+          />
+          <StatsCard
+            title="Completed"
+            value={stats.byStatus?.COMPLETED ?? 0}
+            icon={Eye}
+          />
+          <StatsCard
+            title="Total Value"
+            value={formatCurrency(stats.totalValue ?? 0)}
+            icon={DollarSign}
+          />
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3">
+        <div className="w-40">
+          <Select
+            options={STATUS_OPTIONS}
+            value={statusFilter}
+            onChange={(e) => {
+              setStatusFilter(e.target.value)
+              setPage(1)
+            }}
+          />
+        </div>
+        <div className="w-40">
+          <Select
+            options={TYPE_OPTIONS}
+            value={typeFilter}
+            onChange={(e) => {
+              setTypeFilter(e.target.value)
+              setPage(1)
+            }}
+          />
+        </div>
+        <div className="w-44">
+          <Select
+            options={SORT_OPTIONS}
+            value={sortBy}
+            onChange={(e) => {
+              setSortBy(e.target.value)
+              setPage(1)
+            }}
+          />
+        </div>
       </div>
+
+      {/* Table */}
+      <DataTable<Contract>
+        columns={columns}
+        data={(data?.data ?? []) as (Contract & Record<string, unknown>)[]}
+        loading={isLoading}
+        page={page}
+        totalPages={data?.totalPages}
+        onPageChange={setPage}
+        sortBy={sortBy}
+        sortOrder={sortOrder}
+        onSort={handleSort}
+        onRowClick={(row) => setSelectedId(row.id as string)}
+        rowKey={(row) => row.id as string}
+        emptyTitle="No contracts found"
+        emptyDescription="Contracts assigned to you will appear here."
+      />
     </div>
   )
 }

--- a/agent-ui/src/types/index.ts
+++ b/agent-ui/src/types/index.ts
@@ -197,6 +197,105 @@ export interface CreateClientPayload {
 
 export type UpdateClientPayload = Partial<CreateClientPayload>
 
+// ─── Contract ────────────────────────────────────────────────────
+
+export type ContractType = 'SALE' | 'RENT' | 'LEASE'
+export type ContractStatus = 'DRAFT' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED' | 'EXPIRED'
+export type InvoiceStatus = 'PENDING' | 'PAID' | 'OVERDUE' | 'CANCELLED'
+export type PaymentMethod = 'CASH' | 'BANK_TRANSFER' | 'CHECK' | 'CREDIT_CARD' | 'INSTALLMENT'
+
+export interface Contract {
+  id: string
+  type: ContractType
+  status: ContractStatus
+  propertyId: string
+  property?: { id: string; title: string; address?: string } | null
+  clientId: string
+  client?: { id: string; firstName: string; lastName: string; phone: string; email?: string | null } | null
+  agentId?: string | null
+  agent?: { id: string; name: string } | null
+  startDate: string
+  endDate?: string | null
+  totalAmount: number
+  paymentTerms?: Record<string, unknown> | null
+  documentUrl?: string | null
+  notes?: string | null
+  createdAt: string
+  updatedAt: string
+  _count?: { invoices?: number }
+}
+
+export interface Invoice {
+  id: string
+  contractId: string
+  amount: number
+  dueDate: string
+  status: InvoiceStatus
+  paidDate?: string | null
+  paymentMethod?: PaymentMethod | null
+}
+
+export interface ContractDetail extends Contract {
+  invoices: Invoice[]
+}
+
+export interface ContractFilter {
+  page?: number
+  pageSize?: number
+  type?: ContractType
+  status?: ContractStatus
+  clientId?: string
+  propertyId?: string
+  agentId?: string
+  dateFrom?: string
+  dateTo?: string
+  sortBy?: 'createdAt' | 'startDate' | 'endDate' | 'totalAmount'
+  sortOrder?: 'asc' | 'desc'
+}
+
+export interface ContractStats {
+  total: number
+  byStatus: Record<ContractStatus, number>
+  byType: Record<ContractType, number>
+  totalValue: number
+}
+
+// ─── Activity ────────────────────────────────────────────────────
+
+export type ActivityEntityType = 'PROPERTY' | 'CLIENT' | 'LEAD' | 'CONTRACT' | 'INVOICE'
+
+export interface Activity {
+  id: string
+  type: string
+  description: string
+  entityType: ActivityEntityType
+  entityId: string
+  performedBy: string
+  metadata?: Record<string, unknown> | null
+  createdAt: string
+  user?: { id: string; name: string } | null
+}
+
+export interface ActivityFilter {
+  page?: number
+  pageSize?: number
+  type?: string
+  entityType?: ActivityEntityType
+  entityId?: string
+  performedBy?: string
+  from?: string
+  to?: string
+}
+
+export interface CreateActivityPayload {
+  type: string
+  description: string
+  entityType: ActivityEntityType
+  entityId: string
+  performedBy: string
+  metadata?: Record<string, unknown>
+}
+
 // Theme
 export type Theme = 'light' | 'dark'
 


### PR DESCRIPTION
## Summary
- **Contracts API & Page**: Read-only contract list with filters (status, type, sort), stats cards, and drill-down to contract detail with invoice schedule and activity timeline
- **Activities API & Page**: Filterable activity log with scope (all/mine), entity type, and action type filters, plus paginated list view
- **ActivityLog component**: Reusable timeline component that fetches activities for any entity (used on ContractDetailPage)
- **QuickLogActivity FAB**: Floating action button to quickly log calls, meetings, or notes from any page

Closes #23

## Test plan
- [ ] Navigate to /contracts and verify contract list loads with filters and stats
- [ ] Click a contract row to open detail view with property, client, financials, invoice schedule
- [ ] Navigate to /activities and verify activity list loads with filters
- [ ] Toggle "My Activities" scope filter
- [ ] Click the floating + button to open quick-log panel; submit a call/meeting/note
- [ ] Verify activity timeline appears on contract detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)