### PR TITLE
fix: add Contract.agentId foreign key relation to User

### DIFF
--- a/prisma/migrations/20260326_add_contract_agent_relation/migration.sql
+++ b/prisma/migrations/20260326_add_contract_agent_relation/migration.sql
@@ -1,0 +1,5 @@
+-- AddForeignKey
+ALTER TABLE "contracts" ADD CONSTRAINT "contracts_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "contracts_agentId_idx" ON "contracts"("agentId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,6 +136,7 @@ model User {
   assignedProperties Property[] @relation("PropertyAgent")
   assignedClients    Client[]   @relation("ClientAgent")
   assignedLeads      Lead[]     @relation("LeadAgent")
+  assignedContracts  Contract[] @relation("ContractAgent")
   emailPreference    EmailPreference?
 
   @@index([authmeId])
@@ -283,11 +284,13 @@ model Contract {
 
   property     Property       @relation(fields: [propertyId], references: [id], onDelete: Restrict)
   client       Client         @relation(fields: [clientId], references: [id], onDelete: Restrict)
+  agent        User?          @relation("ContractAgent", fields: [agentId], references: [id], onDelete: SetNull)
   invoices     Invoice[]
 
   @@index([status])
   @@index([propertyId])
   @@index([clientId])
+  @@index([agentId])
   @@index([createdAt])
   @@map("contracts")
 }

--- a/src/contracts/contracts.service.ts
+++ b/src/contracts/contracts.service.ts
@@ -69,6 +69,7 @@ export class ContractsService {
         include: {
           property: true,
           client: true,
+          agent: true,
         },
       });
 
@@ -133,6 +134,7 @@ export class ContractsService {
         include: {
           property: { select: { id: true, title: true, type: true, status: true, city: true } },
           client: { select: { id: true, firstName: true, lastName: true, phone: true } },
+          agent: { select: { id: true, firstName: true, lastName: true, email: true } },
           _count: { select: { invoices: true } },
         },
       }),
@@ -148,6 +150,7 @@ export class ContractsService {
       include: {
         property: true,
         client: true,
+        agent: true,
         invoices: { orderBy: { dueDate: 'asc' } },
       },
     });
@@ -194,6 +197,7 @@ export class ContractsService {
       include: {
         property: true,
         client: true,
+        agent: true,
       },
     });
   }
@@ -400,6 +404,7 @@ export class ContractsService {
       include: {
         property: { select: { id: true, title: true, city: true } },
         client: { select: { id: true, firstName: true, lastName: true, phone: true } },
+        agent: { select: { id: true, firstName: true, lastName: true, email: true } },
       },
     });
   }


### PR DESCRIPTION
## Summary
- Adds a proper Prisma relation from `Contract.agentId` to `User` model with `onDelete: SetNull`, matching the pattern used by Property, Client, and Lead
- Adds reverse relation `assignedContracts` on User model
- Adds database index on `contracts.agentId` for query performance
- Includes agent data in contract query results (list, detail, update, expiring)

Closes #86

## Test plan
- [x] `prisma validate` passes
- [x] TypeScript compiles with no errors
- [x] All 30 contract tests pass
- [ ] Run migration against dev database and verify FK constraint works
- [ ] Verify contract list/detail API responses now include agent data

🤖 Generated with [Claude Code](https://claude.com/claude-code)