### PR TITLE
fix: replace default PostgreSQL credentials with secure placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ─── Database ──────────────────────────────────────────────────────────
 # PostgreSQL connection string
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/real_estate_crm
+DATABASE_URL=postgresql://crm_user:CHANGE_ME_TO_A_STRONG_PASSWORD@localhost:5432/real_estate_crm
 
 # ─── Authme IAM ───────────────────────────────────────────────────────
 # Base URL of the Authme server (no trailing slash)
@@ -27,8 +27,8 @@ NODE_ENV=development
 UPLOAD_DIR=./uploads
 
 # ─── Docker Compose (production only) ─────────────────────────────────
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+POSTGRES_USER=crm_user
+POSTGRES_PASSWORD=CHANGE_ME_TO_A_STRONG_PASSWORD
 POSTGRES_DB=real_estate_crm
 HTTP_PORT=80
 HTTPS_PORT=443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:?Set POSTGRES_USER in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
       POSTGRES_DB: ${POSTGRES_DB:-real_estate_crm}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -37,7 +37,7 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3000"
-      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-real_estate_crm}
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-real_estate_crm}
       AUTHME_URL: ${AUTHME_URL:-http://localhost:3001}
       AUTHME_REALM: ${AUTHME_REALM:-real-estate}
       AUTHME_CLIENT_ID: ${AUTHME_CLIENT_ID:-crm-backend}

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,18 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api/docs', app, document);
 
+  // Warn about insecure default credentials in production
+  const dbUrl = process.env['DATABASE_URL'] ?? '';
+  const isProduction = process.env['NODE_ENV'] === 'production';
+  const hasDefaultCreds =
+    dbUrl.includes(':postgres@') || dbUrl.includes(':password@');
+  if (isProduction && hasDefaultCreds) {
+    console.warn(
+      '\n⚠️  WARNING: Database credentials appear to use default/weak values.\n' +
+        '   This is a security risk in production. Update POSTGRES_USER and POSTGRES_PASSWORD in your .env file.\n',
+    );
+  }
+
   const port = process.env['PORT'] ?? 3000;
   await app.listen(port);
   console.log(`Real Estate CRM API is running on http://localhost:${port}`);


### PR DESCRIPTION
## Summary
Closes #95

- **`.env.example`**: Replaced default `postgres:postgres` credentials with `crm_user:CHANGE_ME_TO_A_STRONG_PASSWORD` placeholders so developers must set real credentials before deploying.
- **`docker-compose.yml`**: Changed `POSTGRES_USER` and `POSTGRES_PASSWORD` to use `${VAR:?error}` syntax — docker compose now **fails fast** if these aren't set in `.env`, instead of silently falling back to insecure defaults.
- **`src/main.ts`**: Added a startup warning in production if the DATABASE_URL still contains default/weak credentials.

## Test plan
- [ ] Verify `docker compose config` fails without `.env` configured (POSTGRES_USER/PASSWORD required)
- [ ] Verify `.env.example` no longer contains `postgres:postgres`
- [ ] Verify backend logs a warning when started in production mode with default credentials
- [ ] Verify existing dev setup works after copying and editing `.env.example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)